### PR TITLE
fix: allow release-plz to use crates.io registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ documentation = "https://docs.rs/pglite-oxide"
 keywords = ["postgres", "pglite", "wasm", "database", "embedded"]
 categories = ["database-implementations", "wasm", "development-tools::testing"]
 license = "MIT AND Apache-2.0 AND PostgreSQL"
-publish = ["crates-io"]
 exclude = [
   ".config/**",
   ".github/**",

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -15,6 +15,9 @@ user-facing binary to distribute.
 - Repository Actions settings must allow GitHub Actions to create pull requests.
 - The `Release` workflow needs `contents: write`, `pull-requests: write`, and
   `id-token: write`; these are already declared in the workflow.
+- Do not set `package.publish = ["crates-io"]`; crates.io is Cargo's default
+  registry, and release-plz treats `package.publish` entries as named alternate
+  registries.
 
 ## Release intent
 


### PR DESCRIPTION
## Summary
- remove the manifest alternate-registry publish list so release-plz uses Cargo's default crates.io registry
- document why `package.publish = ["crates-io"]` should not be reintroduced

## Verification
- `taplo fmt --check Cargo.toml release-plz.toml`
- `cargo metadata --no-deps --format-version 1` reports `publish: null` for `pglite-oxide`
- `cargo package --locked --allow-dirty`
- `cargo publish --locked --dry-run --allow-dirty`
- `cargo check --all-targets --locked`

The failed `publish-dry-run` workflow passed all package checks and failed only in release-plz with `The registry 'crates-io' could not be found`. After this merges, rerun `Release` from `main` with `publish-dry-run`, then `publish` if it passes.