### PR TITLE
fix: run real release without dry-run input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,18 +119,27 @@ jobs:
       - name: Inspect package contents
         run: cargo package --locked --list
 
-      - name: Run release-plz
-        id: release_plz
+      - name: Run release-plz dry run
+        if: ${{ inputs.operation == 'publish-dry-run' }}
         uses: release-plz/action@v0.5
         with:
           command: release
-          dry_run: ${{ inputs.operation == 'publish-dry-run' }}
+          dry_run: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run release-plz publish
+        if: ${{ inputs.operation == 'publish' }}
+        id: release_plz_publish
+        uses: release-plz/action@v0.5
+        with:
+          command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Require release output
-        if: ${{ steps.release_plz.outputs.releases_created != 'true' }}
+        if: ${{ inputs.operation == 'publish' && steps.release_plz_publish.outputs.releases_created != 'true' }}
         run: |
           echo "release-plz completed without creating a release." >&2
-          echo "Check that Cargo.toml contains an unpublished version and that release-plz is allowed to release the current main commit." >&2
+          echo "Check that Cargo.toml contains an unpublished version and that release-plz was run without dry_run." >&2
           exit 1

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -50,7 +50,8 @@ The manual publish job uses `release_always = true` because the workflow is not
 triggered on every merge; it only runs when a maintainer explicitly selects a
 publish operation. The job fails if release-plz reports that it created no
 release, so a green publish run means a crate/GitHub release was actually
-produced.
+produced. The dry-run and publish action steps are intentionally separate so the
+real publish step omits the `dry_run` input entirely.
 
 release-plz publishes unpublished package versions to crates.io, creates the bare
 SemVer tag such as `0.2.0`, and creates the GitHub release from the generated


### PR DESCRIPTION
## Summary
- split release-plz dry-run and publish into separate workflow steps
- omit the `dry_run` input entirely on the real publish path
- keep the no-op guard only for real publish runs

## Verification
- `actionlint .github/workflows/release.yml .github/workflows/ci.yml .github/workflows/conventional-commits.yml`
- `taplo fmt --check release-plz.toml Cargo.toml`
- `git diff --check`

## Context
The failed publish run passed `dry_run: false`, but release-plz/action v0.5 treated the non-empty string `false` as dry-run and logged: `due to dry, skipping the following: ["cargo registry upload", "creation of tag '0.2.0'", "creation of git release"]`. This change makes publish omit that input entirely.