### PR TITLE
ci: harden release note validation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,0 @@
-[profile.default]
-slow-timeout = { period = "10s", terminate-after = 6, grace-period = "0s" }
-status-level = "fail"
-final-status-level = "fail"

--- a/.github/scripts/check-release-changelog.sh
+++ b/.github/scripts/check-release-changelog.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$root"
+
+package_version="$(
+  awk '
+    /^\[package\][[:space:]]*$/ {
+      in_package = 1
+      next
+    }
+    /^\[/ && in_package {
+      exit
+    }
+    in_package && $0 ~ /^[[:space:]]*version[[:space:]]*=/ {
+      line = $0
+      sub(/^[^=]*=[[:space:]]*"/, "", line)
+      sub(/".*$/, "", line)
+      print line
+      exit
+    }
+  ' Cargo.toml
+)"
+
+if [[ -z "${package_version}" ]]; then
+  echo "could not read package version from Cargo.toml" >&2
+  exit 1
+fi
+
+is_version_heading_awk='
+  function is_version_heading(line) {
+    return index(line, "## [" version "] - ") == 1 ||
+      (index(line, "## [" version "](") == 1 &&
+       line ~ /\) - [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/)
+  }
+'
+
+top_release_heading="$(
+  awk '
+    /^## \[Unreleased\]/ {
+      seen_unreleased = 1
+      next
+    }
+    seen_unreleased && /^## \[/ {
+      print
+      exit
+    }
+  ' CHANGELOG.md
+)"
+
+if [[ -z "${top_release_heading}" ]]; then
+  echo "CHANGELOG.md does not contain a release section after [Unreleased]" >&2
+  exit 1
+fi
+
+if ! awk -v version="${package_version}" -v heading="${top_release_heading}" "${is_version_heading_awk}"'
+  BEGIN {
+    exit is_version_heading(heading) ? 0 : 1
+  }
+'; then
+  cat >&2 <<EOF
+CHANGELOG.md top release section does not match Cargo.toml version.
+
+Cargo.toml version:
+  ${package_version}
+
+Top changelog release section:
+  ${top_release_heading}
+
+Run the Release workflow with prepare-release-pr and merge the generated
+release-plz PR before running publish or publish-dry-run.
+EOF
+  exit 1
+fi
+
+if ! awk -v version="${package_version}" "${is_version_heading_awk}"'
+  is_version_heading($0) {
+    in_section = 1
+    next
+  }
+  in_section && /^## \[/ {
+    exit
+  }
+  in_section && $0 ~ /[^[:space:]]/ && $0 !~ /^### / {
+    found_body = 1
+  }
+  END {
+    exit found_body ? 0 : 1
+  }
+' CHANGELOG.md; then
+  cat >&2 <<EOF
+CHANGELOG.md has a ${package_version} release section, but it has no release
+note body.
+
+Run release-plz release-pr to regenerate the changelog section before
+publishing.
+EOF
+  exit 1
+fi
+
+expected_unreleased="[Unreleased]: https://github.com/f0rr0/pglite-oxide/compare/${package_version}...HEAD"
+
+if ! grep -Fxq "${expected_unreleased}" CHANGELOG.md; then
+  cat >&2 <<EOF
+CHANGELOG.md [Unreleased] compare link does not start from ${package_version}.
+
+Expected:
+  ${expected_unreleased}
+
+This usually means the changelog was not updated for the package version that
+is about to be published.
+EOF
+  exit 1
+fi
+
+echo "release changelog matches package version ${package_version}"

--- a/.github/scripts/check-release-intent.sh
+++ b/.github/scripts/check-release-intent.sh
@@ -16,6 +16,57 @@ release_pr_pattern='^chore\(release\): .+'
 
 affected_files=()
 
+is_release_pr=false
+if [[ "${subject}" =~ ${release_pr_pattern} && "${head_branch}" == release-plz-* ]]; then
+  is_release_pr=true
+fi
+
+package_version_from_ref() {
+  local ref="${1:?package_version_from_ref requires a git ref}"
+
+  git show "${ref}:Cargo.toml" | awk '
+    /^\[package\][[:space:]]*$/ {
+      in_package = 1
+      next
+    }
+    /^\[/ && in_package {
+      exit
+    }
+    in_package && $0 ~ /^[[:space:]]*version[[:space:]]*=/ {
+      line = $0
+      sub(/^[^=]*=[[:space:]]*"/, "", line)
+      sub(/".*$/, "", line)
+      print line
+      exit
+    }
+  '
+}
+
+base_version="$(package_version_from_ref "${base_ref}")"
+head_version="$(package_version_from_ref "${head_ref}")"
+
+if [[ -z "${base_version}" || -z "${head_version}" ]]; then
+  echo "could not read package version from Cargo.toml" >&2
+  exit 1
+fi
+
+if [[ "${base_version}" != "${head_version}" && "${is_release_pr}" != true ]]; then
+  cat >&2 <<EOF
+This PR changes the root package version from ${base_version} to ${head_version}.
+
+Package version bumps are release-plz owned. Run the Release workflow with
+prepare-release-pr and merge the generated release-plz PR instead of changing
+the version in a feature/fix PR.
+
+release-plz PRs are allowed only when their branch starts with release-plz- and
+their title starts with chore(release):.
+
+Received:
+  ${subject}
+EOF
+  exit 1
+fi
+
 while IFS= read -r file; do
   [[ -z "${file}" ]] && continue
 
@@ -34,7 +85,7 @@ if [[ "${subject}" =~ ${release_pattern} ]]; then
   exit 0
 fi
 
-if [[ "${subject}" =~ ${release_pr_pattern} && "${head_branch}" == release-plz-* ]]; then
+if [[ "${is_release_pr}" == true ]]; then
   exit 0
 fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,9 @@ jobs:
         with:
           tool: prek@${{ env.PREK_VERSION }}
 
+      - name: Validate release changelog
+        run: .github/scripts/check-release-changelog.sh
+
       - name: Validate package checks
         run: scripts/validate.sh ci
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-26
+
+### Breaking
+
+- Default runtime startup now uses the optimized embedded-template path.
+- `ensure_cluster` now requires runtime options.
+- Runtime packaging now uses the uncompressed `pglite-wasi.tar` asset.
+
+### Added
+
+- Added reusable Wasmtime engine/module caching and on-disk compiled `.cwasm`
+  cache support for faster startup.
+- Added an embedded prepopulated PGDATA template with manifest validation.
+- Added a vanilla Tauri v2 SQLx profiler example with release-mode workload
+  reporting.
+- Added repo hooks for Conventional Commit validation, formatting, and pre-push
+  checks.
+
+### Changed
+
+- Quieted WASI stdio by default and prefer Unix sockets where available.
+- Streamlined runtime, release, contributing, and usage docs around the optimized
+  default path.
+
+### Fixed
+
+- Hardened proxy frontend framing for SSL requests, cancel requests,
+  split/coalesced packets, and extended-query batching.
+
 ## [0.2.0] - 2026-04-24
 
 ### Added
@@ -27,6 +56,7 @@ and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Initial repository release.
 
-[Unreleased]: https://github.com/f0rr0/pglite-oxide/compare/0.2.0...HEAD
+[Unreleased]: https://github.com/f0rr0/pglite-oxide/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/f0rr0/pglite-oxide/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/f0rr0/pglite-oxide/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/f0rr0/pglite-oxide/releases/tag/0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["postgres", "pglite", "wasm", "database", "embedded"]
 categories = ["database-implementations", "wasm", "development-tools::testing"]
 license = "MIT AND Apache-2.0 AND PostgreSQL"
 exclude = [
-  ".config/**",
   ".github/**",
   "Cargo.toml.orig",
   "assets/bin/pg_dump.wasm",

--- a/README.md
+++ b/README.md
@@ -89,16 +89,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 For app persistence, use `PgliteServer::builder().path("./.pglite").start()?`.
 
-## Current Shape
-
-`pglite-oxide` is a Wasmtime/WASI embedding of PGlite, not native `libpglite`
-bindings. Fresh databases are created from the bundled PGDATA template, and
-later process starts reuse the compiled module cache when possible.
-
-Prefer the direct `Pglite` API when you do not need a PostgreSQL connection
-string. Use `PgliteServer` for compatibility with existing Postgres client
-crates.
-
 ## Docs
 
 - [Usage guide](https://github.com/f0rr0/pglite-oxide/blob/main/docs/USAGE.md)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -38,6 +38,11 @@ types such as `docs:`, `ci:`, `chore:`, `style:`, or `test:`. The CI release
 intent check treats these paths as release-affecting: `Cargo.toml`, `Cargo.lock`,
 `build.rs`, `src/**`, `assets/**`, `examples/**`, and `benches/**`.
 
+Package version bumps are release-plz owned. Feature and fix PRs may change
+package code, dependencies, and assets, but they must not change the root
+`Cargo.toml` package version. The version bump and matching `CHANGELOG.md`
+section must come from a `release-plz-*` PR titled `chore(release): ...`.
+
 ## Releasing from main
 
 1. Merge release-worthy work to `main`.
@@ -54,6 +59,13 @@ publish operation. The job fails if release-plz reports that it created no
 release, so a green publish run means a crate/GitHub release was actually
 produced. The dry-run and publish action steps are intentionally separate so the
 real publish step omits the `dry_run` input entirely.
+
+The publish job also validates release-note readiness before running expensive
+package checks. The current root package version must be the first release
+section in `CHANGELOG.md`, that section must contain release-note body content,
+and the `[Unreleased]` compare link must start at that version. If this check
+fails, run `prepare-release-pr` and merge the generated release-plz PR before
+publishing.
 
 release-plz publishes unpublished package versions to crates.io, creates the bare
 SemVer tag such as `0.3.0`, and creates the GitHub release from the generated


### PR DESCRIPTION
## Summary
- block manual root package version bumps outside release-plz PRs
- add a publish preflight that requires the current Cargo.toml version to match the top CHANGELOG release section
- restore the missing 0.3.0 changelog section and remove the README Current Shape section

## Validation
- .github/scripts/check-release-changelog.sh
- bash -n .github/scripts/check-release-changelog.sh .github/scripts/check-release-intent.sh
- actionlint .github/workflows/release.yml .github/workflows/conventional-commits.yml
- git diff --check
- scripts/validate.sh pre-commit
- cargo package --locked --no-verify --allow-dirty
- scripts/check-crate-size.sh --enforce
- cargo publish --dry-run --locked --allow-dirty
- pre-push hook via git push: git diff --check, cargo clippy --all-targets --locked -- -D warnings, cargo test --all-targets --locked -- --nocapture