### PR TITLE
fix: align changelog guard with release-plz

### DIFF
--- a/.github/scripts/check-release-changelog.sh
+++ b/.github/scripts/check-release-changelog.sh
@@ -99,17 +99,19 @@ EOF
   exit 1
 fi
 
+unreleased_links="$(grep -E '^\[Unreleased\]:' CHANGELOG.md || true)"
 expected_unreleased="[Unreleased]: https://github.com/f0rr0/pglite-oxide/compare/${package_version}...HEAD"
 
-if ! grep -Fxq "${expected_unreleased}" CHANGELOG.md; then
+if [[ -n "${unreleased_links}" ]] && ! grep -Fxq "${expected_unreleased}" <<< "${unreleased_links}"; then
   cat >&2 <<EOF
 CHANGELOG.md [Unreleased] compare link does not start from ${package_version}.
 
 Expected:
   ${expected_unreleased}
 
-This usually means the changelog was not updated for the package version that
-is about to be published.
+release-plz's default changelog format uses inline release links and does not
+maintain footer-style compare links. Either remove the [Unreleased] footer link
+or update it before publishing.
 EOF
   exit 1
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-04-26
+## [0.3.0](https://github.com/f0rr0/pglite-oxide/compare/0.2.0...0.3.0) - 2026-04-26
 
 ### Breaking
 
@@ -37,7 +37,7 @@ and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Hardened proxy frontend framing for SSL requests, cancel requests,
   split/coalesced packets, and extended-query batching.
 
-## [0.2.0] - 2026-04-24
+## [0.2.0](https://github.com/f0rr0/pglite-oxide/compare/0.1.0...0.2.0) - 2026-04-24
 
 ### Added
 
@@ -52,11 +52,6 @@ and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Improved the blocking proxy/server path for extended-protocol clients,
   readiness handling, and socket mode behavior.
 
-## [0.1.0] - 2025-09-27
+## [0.1.0](https://github.com/f0rr0/pglite-oxide/releases/tag/0.1.0) - 2025-09-27
 
 - Initial repository release.
-
-[Unreleased]: https://github.com/f0rr0/pglite-oxide/compare/0.3.0...HEAD
-[0.3.0]: https://github.com/f0rr0/pglite-oxide/compare/0.2.0...0.3.0
-[0.2.0]: https://github.com/f0rr0/pglite-oxide/compare/0.1.0...0.2.0
-[0.1.0]: https://github.com/f0rr0/pglite-oxide/releases/tag/0.1.0


### PR DESCRIPTION
Align CHANGELOG.md and the release changelog guard with release-plz default inline release links. Footer-style [Unreleased] compare links remain supported when present, but are no longer required.