### PR TITLE
fix: refresh example locks for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,41 @@ jobs:
           cache: "false"
 
       - name: Create or update release PR
+        id: release_plz_pr
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Refresh release PR example lockfiles
+        if: ${{ steps.release_plz_pr.outputs.pr != '' && steps.release_plz_pr.outputs.pr != 'null' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.release_plz_pr.outputs.pr }}
+        run: |
+          set -euo pipefail
+
+          pr_number="$(jq -r '.number // empty' <<< "${PR}")"
+          if [[ -z "${pr_number}" ]]; then
+            echo "release-plz did not return a release PR; skipping example lockfile refresh"
+            exit 0
+          fi
+
+          gh auth setup-git
+          gh pr checkout "${pr_number}"
+          scripts/sync-example-lockfiles.py
+
+          if git diff --quiet -- examples/tauri-sqlx-vanilla/src-tauri/Cargo.lock; then
+            echo "example lockfiles already current"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add examples/tauri-sqlx-vanilla/src-tauri/Cargo.lock
+          git commit -m "chore(release): refresh example lockfiles"
+          git push
 
   publish:
     name: Publish release

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ node_modules/
 /crates/assets/assets/
 /crates/aot/*/artifacts/
 **/.DS_Store
+__pycache__/
 # Build artifacts from cargo package
 pglite_oxide-*.crates.tar.gz

--- a/examples/tauri-sqlx-vanilla/src-tauri/Cargo.lock
+++ b/examples/tauri-sqlx-vanilla/src-tauri/Cargo.lock
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "pglite-oxide"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3556,23 +3556,23 @@ dependencies = [
 
 [[package]]
 name = "pglite-oxide-aot-aarch64-apple-darwin"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "pglite-oxide-aot-aarch64-unknown-linux-gnu"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "pglite-oxide-aot-x86_64-pc-windows-msvc"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "pglite-oxide-aot-x86_64-unknown-linux-gnu"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "pglite-oxide-assets"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/prek.toml
+++ b/prek.toml
@@ -38,5 +38,6 @@ hooks = [
   { id = "git-diff-check", name = "git diff --check", language = "system", entry = "git diff --check", pass_filenames = false, always_run = true, stages = ["pre-push"] },
   { id = "pre-push-fmt", name = "pre-push cargo fmt", language = "system", entry = "cargo fmt --all --check", pass_filenames = false, always_run = true, stages = ["pre-push"] },
   { id = "asset-input-fingerprint", name = "asset input fingerprint", language = "system", entry = "scripts/check-asset-input-fingerprint.sh", pass_filenames = false, always_run = true, stages = ["pre-push"] },
+  { id = "example-lockfiles", name = "example lockfiles", language = "system", entry = "scripts/check-example-lockfiles.sh", pass_filenames = false, always_run = true, stages = ["pre-push"] },
   { id = "pre-push-check", name = "pre-push cargo check", language = "system", entry = "cargo check --workspace --locked", pass_filenames = false, always_run = true, stages = ["pre-push"] },
 ]

--- a/scripts/check-example-lockfiles.sh
+++ b/scripts/check-example-lockfiles.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$root"
+
+base_ref="${EXAMPLE_LOCK_BASE_REF:-}"
+if [[ -z "$base_ref" ]]; then
+  if git rev-parse --verify -q '@{upstream}' >/dev/null; then
+    base_ref='@{upstream}'
+  else
+    base_ref='origin/main'
+  fi
+fi
+
+if ! git rev-parse --verify -q "${base_ref}^{commit}" >/dev/null; then
+  echo "example lockfile check skipped: ${base_ref} is not available" >&2
+  exit 0
+fi
+
+changed="$(
+  git diff --name-only "${base_ref}...HEAD" -- \
+    Cargo.toml \
+    Cargo.lock \
+    crates/assets/Cargo.toml \
+    crates/aot \
+    examples/tauri-sqlx-vanilla/src-tauri/Cargo.lock \
+    scripts/check-example-lockfiles.sh \
+    scripts/sync-example-lockfiles.py
+)"
+
+if [[ -z "$changed" ]]; then
+  echo "example lockfile check skipped: no package version or lockfile changes"
+  exit 0
+fi
+
+scripts/sync-example-lockfiles.py --check

--- a/scripts/sync-example-lockfiles.py
+++ b/scripts/sync-example-lockfiles.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+import argparse
+import pathlib
+import re
+import sys
+import tomllib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+LOCKFILES = [
+    ROOT / "examples/tauri-sqlx-vanilla/src-tauri/Cargo.lock",
+]
+INTERNAL_PACKAGE_MANIFESTS = [
+    ROOT / "Cargo.toml",
+    ROOT / "crates/assets/Cargo.toml",
+    ROOT / "crates/aot/aarch64-apple-darwin/Cargo.toml",
+    ROOT / "crates/aot/aarch64-unknown-linux-gnu/Cargo.toml",
+    ROOT / "crates/aot/x86_64-pc-windows-msvc/Cargo.toml",
+    ROOT / "crates/aot/x86_64-unknown-linux-gnu/Cargo.toml",
+]
+PACKAGE_START_RE = re.compile(r"^\s*\[\[package\]\]\s*$")
+STRING_KEY_RE = re.compile(r'^\s*([A-Za-z0-9_-]+)\s*=\s*"([^"]*)"\s*(?:#.*)?$')
+VERSION_LINE_RE = re.compile(r'^(\s*version\s*=\s*)"[^"]*"(\s*(?:#.*)?)$')
+
+
+def load_internal_versions() -> dict[str, str]:
+    versions = {}
+    for manifest in INTERNAL_PACKAGE_MANIFESTS:
+        data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+        package = data.get("package")
+        if not isinstance(package, dict):
+            raise SystemExit(f"{manifest.relative_to(ROOT)} is missing [package]")
+        name = package.get("name")
+        version = package.get("version")
+        if not isinstance(name, str) or not isinstance(version, str):
+            raise SystemExit(f"{manifest.relative_to(ROOT)} is missing package.name/version")
+        versions[name] = version
+    return versions
+
+
+def strip_newline(line: str) -> tuple[str, str]:
+    if line.endswith("\r\n"):
+        return line[:-2], "\r\n"
+    if line.endswith("\n"):
+        return line[:-1], "\n"
+    return line, ""
+
+
+def string_key(line: str, key: str) -> str | None:
+    body, _ = strip_newline(line)
+    match = STRING_KEY_RE.match(body)
+    if match and match.group(1) == key:
+        return match.group(2)
+    return None
+
+
+def replace_version_line(line: str, version: str) -> str:
+    body, newline = strip_newline(line)
+    match = VERSION_LINE_RE.match(body)
+    if not match:
+        raise SystemExit(f"cannot update Cargo.lock version line: {line.rstrip()}")
+    return f'{match.group(1)}"{version}"{match.group(2)}{newline}'
+
+
+def package_block_ranges(lines: list[str]) -> list[tuple[int, int]]:
+    starts = [idx for idx, line in enumerate(lines) if PACKAGE_START_RE.match(line)]
+    return [
+        (start, starts[pos + 1] if pos + 1 < len(starts) else len(lines))
+        for pos, start in enumerate(starts)
+    ]
+
+
+def check_lockfile_contains_path_packages(lockfile: pathlib.Path, versions: dict[str, str]) -> None:
+    data = tomllib.loads(lockfile.read_text(encoding="utf-8"))
+    packages = data.get("package")
+    if not isinstance(packages, list):
+        raise SystemExit(f"{lockfile.relative_to(ROOT)} is missing [[package]] entries")
+
+    present = {
+        package.get("name")
+        for package in packages
+        if isinstance(package, dict) and package.get("name") in versions and "source" not in package
+    }
+    missing = sorted(set(versions) - present)
+    if missing:
+        raise SystemExit(
+            f"{lockfile.relative_to(ROOT)} is missing internal path packages: {', '.join(missing)}"
+        )
+
+
+def sync_lockfile(lockfile: pathlib.Path, versions: dict[str, str]) -> list[str]:
+    check_lockfile_contains_path_packages(lockfile, versions)
+    lines = lockfile.read_text(encoding="utf-8").splitlines(keepends=True)
+    changes = []
+
+    for start, end in package_block_ranges(lines):
+        block = lines[start:end]
+        name = None
+        version_idx = None
+        current_version = None
+        has_source = False
+
+        for offset, line in enumerate(block):
+            if string_key(line, "source") is not None:
+                has_source = True
+            key_name = string_key(line, "name")
+            if key_name is not None:
+                name = key_name
+            key_version = string_key(line, "version")
+            if key_version is not None:
+                version_idx = start + offset
+                current_version = key_version
+
+        if name not in versions or has_source:
+            continue
+        if version_idx is None or current_version is None:
+            raise SystemExit(f"{lockfile.relative_to(ROOT)} package {name} is missing version")
+
+        expected_version = versions[name]
+        if current_version != expected_version:
+            lines[version_idx] = replace_version_line(lines[version_idx], expected_version)
+            changes.append(
+                f"{lockfile.relative_to(ROOT)}: {name} {current_version} -> {expected_version}"
+            )
+
+    if changes:
+        lockfile.write_text("".join(lines), encoding="utf-8")
+    return changes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="fail instead of writing updates")
+    args = parser.parse_args()
+
+    versions = load_internal_versions()
+    all_changes = []
+    for lockfile in LOCKFILES:
+        before = lockfile.read_text(encoding="utf-8")
+        changes = sync_lockfile(lockfile, versions)
+        if args.check and changes:
+            lockfile.write_text(before, encoding="utf-8")
+        all_changes.extend(changes)
+
+    if not all_changes:
+        print("example lockfiles match internal package versions")
+        return 0
+
+    for change in all_changes:
+        print(change, file=sys.stderr)
+    if args.check:
+        print("example lockfiles are stale; run `scripts/sync-example-lockfiles.py`", file=sys.stderr)
+        return 1
+
+    print("updated example lockfiles")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -245,6 +245,7 @@ validate_runtime() {
 validate_examples() {
   require cargo
   require npm
+  run scripts/sync-example-lockfiles.py --check
   run cargo check --manifest-path examples/tauri-sqlx-vanilla/src-tauri/Cargo.toml --locked
   run npm --prefix examples/tauri-sqlx-vanilla ci
   run npm --prefix examples/tauri-sqlx-vanilla run build


### PR DESCRIPTION
## Summary
- refresh the 0.4.0 Tauri example Cargo.lock path package versions
- add a lightweight lockfile sync/check script for example lockfiles
- have release-plz PR preparation update example lockfiles automatically
- run the check in examples CI and pre-push when package versions or lockfiles change

## Verification
- scripts/sync-example-lockfiles.py --check
- scripts/check-example-lockfiles.sh
- python3 -m py_compile scripts/sync-example-lockfiles.py
- bash -n scripts/check-example-lockfiles.sh scripts/validate.sh
- actionlint .github/workflows/release.yml
- git diff --check
- cargo check --manifest-path examples/tauri-sqlx-vanilla/src-tauri/Cargo.toml --locked
- scripts/validate.sh examples
- pre-push hooks on push