### PR TITLE
fix: keep release validation in staged workspace

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -4,7 +4,11 @@ set -eu
 mode="${1:-pre-push}"
 shift || true
 
-root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [ "${PGLITE_OXIDE_RELEASE_STAGED:-0}" = "1" ]; then
+  root="$(pwd)"
+else
+  root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
 cd "$root"
 
 cargo_bin="${CARGO_HOME:-$HOME/.cargo}/bin"


### PR DESCRIPTION
## Summary
- keep scripts/validate.sh rooted at the current directory for PGLITE_OXIDE_RELEASE_STAGED=1
- prevents staged release validation from escaping back to the parent checkout via git rev-parse

## Verification
- sh -n scripts/validate.sh
- cargo run -p xtask -- release stage
- PGLITE_OXIDE_RELEASE_STAGED=1 scripts/validate.sh release --allow-dirty from the staged workspace
- pre-push hooks: git diff --check, cargo fmt, asset input fingerprint, example lockfiles, cargo check