### PR TITLE
fix: quiet expected postgres error recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@
 
 `pglite-oxide` brings PGlite/Postgres to Rust with a small API. Open a database
 directly with `Pglite`, or hand `PgliteServer` to SQLx and any standard
-Postgres client. No local Postgres install, no Docker, no runtime build
-toolchain.
+Postgres client. The packaged runtime is PostgreSQL 17.5. No local Postgres
+install, no Docker, no runtime build toolchain.
 
 ## Add Postgres In One Minute ⚡
 

--- a/src/pglite/postgres_mod.rs
+++ b/src/pglite/postgres_mod.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 use tokio::io::ReadBuf;
 use tokio::runtime::Runtime as TokioRuntime;
-use tracing::warn;
+use tracing::{debug, warn};
 use wasmer::{Engine, Instance, Module, Store, TypedFunction, WasmTypeList};
 use wasmer_config::package::{PackageHash, PackageId};
 use wasmer_types::ModuleHash;
@@ -1254,8 +1254,14 @@ impl PostgresMod {
                 );
                 if let Err(err) = self.protocol.main_loop.call(&mut self.store) {
                     if runtime_error_exit_code(&err) == Some(POSTGRES_MAIN_LONGJMP) {
-                        warn!(
+                        debug!(
                             "PostgresMainLoopOnce used host longjmp fallback; recovering protocol error"
+                        );
+                        self.recover_protocol_error(payload.len())?;
+                        recovered_protocol_error = true;
+                    } else if is_wasm_uncaught_exception(&err) {
+                        debug!(
+                            "PostgresMainLoopOnce trapped for PostgreSQL error; recovering protocol state: {err}"
                         );
                         self.recover_protocol_error(payload.len())?;
                         recovered_protocol_error = true;
@@ -1306,11 +1312,16 @@ impl PostgresMod {
                 if runtime_error_exit_code(&err) == Some(PGLITE_EXIT_ALIVE) {
                     break;
                 }
-                if runtime_error_exit_code(&err) == Some(POSTGRES_MAIN_LONGJMP)
-                    || is_wasm_uncaught_exception(&err)
-                {
-                    warn!(
-                        "PostgresMainLoopOnce used host trap fallback while serving streaming protocol"
+                if runtime_error_exit_code(&err) == Some(POSTGRES_MAIN_LONGJMP) {
+                    debug!(
+                        "PostgresMainLoopOnce used host longjmp fallback while serving streaming protocol"
+                    );
+                    self.protocol.recover_error.call(&mut self.store).context(
+                        "recover Postgres main-loop error while serving streaming protocol",
+                    )?;
+                } else if is_wasm_uncaught_exception(&err) {
+                    debug!(
+                        "PostgresMainLoopOnce trapped for PostgreSQL error while serving streaming protocol: {err}"
                     );
                     self.protocol.recover_error.call(&mut self.store).context(
                         "recover Postgres main-loop error while serving streaming protocol",
@@ -1490,7 +1501,17 @@ impl PostgresMod {
                 "Postgres protocol recovery did not drain buffered input after {drain_attempts} attempts"
             );
             if let Err(drain_err) = self.protocol.main_loop.call(&mut self.store) {
-                warn!("PostgresMainLoopOnce trapped while draining after recovery: {drain_err}");
+                if runtime_error_exit_code(&drain_err) == Some(POSTGRES_MAIN_LONGJMP)
+                    || is_wasm_uncaught_exception(&drain_err)
+                {
+                    debug!(
+                        "PostgresMainLoopOnce trapped while draining after PostgreSQL error recovery: {drain_err}"
+                    );
+                } else {
+                    warn!(
+                        "PostgresMainLoopOnce trapped while draining after recovery: {drain_err}"
+                    );
+                }
                 self.protocol
                     .recover_error
                     .call(&mut self.store)

--- a/tests/postgres_regression.rs
+++ b/tests/postgres_regression.rs
@@ -441,6 +441,40 @@ fn expected_sql_error_recovery_stays_inside_protocol_loop() -> Result<()> {
 }
 
 #[test]
+fn pg17_uuidv4_alias_error_is_recoverable() -> Result<()> {
+    let _trace = TestTrace::new("pg17_uuidv4_alias_error_is_recoverable");
+    let mut db = Pglite::builder().temporary().open()?;
+
+    let built_in = db.query(
+        "SELECT uuid_extract_version(gen_random_uuid())::int AS version",
+        &[],
+        None,
+    )?;
+    assert_eq!(first_row(&built_in)?.get("version"), Some(&json!(4)));
+
+    let err = db
+        .query("SELECT uuidv4() AS id", &[], None)
+        .expect_err("PostgreSQL 17 should not expose the PostgreSQL 18 uuidv4 alias");
+    let pg_error = err
+        .downcast_ref::<pglite_oxide::PgliteError>()
+        .context("uuidv4 error should preserve PostgreSQL fields")?;
+    assert_eq!(pg_error.database_error().code.as_deref(), Some("42883"));
+    assert!(
+        pg_error
+            .database_error()
+            .message
+            .contains("function uuidv4() does not exist"),
+        "unexpected uuidv4 error: {}",
+        pg_error.database_error().message
+    );
+
+    let recovered = db.query("SELECT 7::int AS recovered", &[], None)?;
+    assert_eq!(first_row(&recovered)?.get("recovered"), Some(&json!(7)));
+
+    Ok(())
+}
+
+#[test]
 fn planner_uses_indexes_for_selective_queries_and_updates() -> Result<()> {
     let _trace = TestTrace::new("planner_uses_indexes_for_selective_queries_and_updates");
     let mut db = Pglite::builder().temporary().open()?;


### PR DESCRIPTION
## Summary
- demote expected PostgreSQL ERROR unwind recovery from WARN to debug logging
- add a regression covering PostgreSQL 17 `gen_random_uuid()` and recoverable `uuidv4()` SQLSTATE 42883 behavior
- add a README callout that the packaged runtime is based on PostgreSQL 17.5 and points users to `gen_random_uuid()`

## Verification
- `RUST_LOG=pglite_oxide::pglite::postgres_mod=warn cargo test pg17_uuidv4_alias_error_is_recoverable --test postgres_regression -- --nocapture`
- pre-push hooks: `git diff --check`, `cargo fmt`, asset input fingerprint, example lockfiles, cargo check