### PR TITLE
fix: allow custom extension AOT artifacts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,17 @@ mod protocol;
 #[cfg(feature = "extensions")]
 pub use pglite::extensions;
 
-#[cfg(feature = "extensions")]
-pub use pglite::PgDumpOptions;
 pub use pglite::{
     DataDirArchiveFormat, DataTransferContainer, DescribeQueryParam, DescribeQueryResult,
     DescribeResultField, ExecProtocolOptions, ExecProtocolResult, FieldInfo, GlobalListenerHandle,
     ListenerHandle, NoticeCallback, ParserMap, Pglite, PgliteBuilder, PgliteError, PgliteServer,
     PgliteServerBuilder, PostgresConfig, QueryOptions, QueryTemplate, Results, RowMode, Serializer,
     SerializerMap, TemplatedQuery, Transaction, TypeParser, format_query, quote_identifier,
+};
+#[cfg(feature = "extensions")]
+pub use pglite::{
+    PgDumpOptions, install_extension_archive_with_aot, install_extension_bytes_with_aot,
+    register_extension_aot_artifact,
 };
 pub use protocol::messages::{BackendMessage, DatabaseError, NoticeMessage};
 

--- a/src/pglite/aot.rs
+++ b/src/pglite/aot.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::{Cursor, Read};
+use std::io::{Cursor, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
@@ -135,6 +135,39 @@ pub(crate) fn load_pg_dump_module(engine: &Engine) -> Result<Module> {
 #[allow(dead_code)]
 pub(crate) fn load_initdb_module(engine: &Engine) -> Result<Module> {
     load_artifact_module(engine, "tool:initdb")
+}
+
+pub(crate) fn install_external_artifact(name: &str, artifact_path: &Path) -> Result<String> {
+    ensure!(
+        !name.is_empty(),
+        "external AOT artifact name must not be empty"
+    );
+    let hash = sha256_file(artifact_path)?;
+    let cache_path = cache_path(name, &hash)?;
+
+    let _guard = AOT_INSTALL_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("AOT install lock poisoned");
+
+    if !cache_path.exists() {
+        if let Some(parent) = cache_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create AOT cache directory {}", parent.display()))?;
+        }
+        let tmp_path =
+            cache_path.with_extension(format!("bin.{}.{}.tmp", std::process::id(), tmp_suffix()));
+        copy_file_atomic(artifact_path, &tmp_path, &cache_path)?;
+    }
+
+    remember_installed_artifact(
+        name,
+        InstalledArtifact {
+            path: cache_path,
+            sha256: hash.clone(),
+        },
+    );
+    Ok(hash)
 }
 
 fn install_artifact(name: &str) -> Result<InstalledArtifact> {
@@ -298,6 +331,28 @@ fn remove_file_if_exists(path: &Path) -> Result<()> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err).with_context(|| format!("remove {}", path.display())),
     }
+}
+
+fn copy_file_atomic(source: &Path, tmp_path: &Path, target: &Path) -> Result<()> {
+    let mut input = fs::File::open(source).with_context(|| format!("open {}", source.display()))?;
+    let mut output =
+        fs::File::create(tmp_path).with_context(|| format!("create {}", tmp_path.display()))?;
+    std::io::copy(&mut input, &mut output)
+        .with_context(|| format!("copy {} to {}", source.display(), tmp_path.display()))?;
+    output
+        .flush()
+        .with_context(|| format!("flush {}", tmp_path.display()))?;
+    if let Err(err) = fs::rename(tmp_path, target) {
+        remove_file_if_exists(tmp_path).ok();
+        return Err(err).with_context(|| {
+            format!(
+                "promote AOT artifact {} -> {}",
+                tmp_path.display(),
+                target.display()
+            )
+        });
+    }
+    Ok(())
 }
 
 fn tmp_suffix() -> u128 {
@@ -531,6 +586,10 @@ fn write_cache_receipt(
         return Err(err).with_context(|| format!("promote AOT cache receipt {}", path.display()));
     }
     Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    sha256_file_with_len(path).map(|(hash, _)| hash)
 }
 
 fn sha256_file_with_len(path: &Path) -> Result<(String, u64)> {

--- a/src/pglite/base.rs
+++ b/src/pglite/base.rs
@@ -620,6 +620,78 @@ pub fn install_extension_bytes(paths: &PglitePaths, bytes: &[u8]) -> Result<()> 
 }
 
 #[cfg(feature = "extensions")]
+pub fn register_extension_aot_artifact(
+    paths: &PglitePaths,
+    native_module_file: &str,
+    aot_artifact_path: &Path,
+) -> Result<()> {
+    let module_file = normalize_extension_module_file(native_module_file)?;
+    let library = paths
+        .pgroot
+        .join("pglite/lib/postgresql")
+        .join(&module_file);
+    ensure!(
+        library.exists(),
+        "extension side module '{}' is not installed at {}",
+        module_file,
+        library.display()
+    );
+    let artifact_name = format!("custom-extension:{module_file}");
+    crate::pglite::aot::install_external_artifact(&artifact_name, aot_artifact_path)?;
+    PostgresMod::register_custom_extension_side_module(&module_file, artifact_name);
+    Ok(())
+}
+
+#[cfg(feature = "extensions")]
+pub fn install_extension_archive_with_aot(
+    paths: &PglitePaths,
+    archive_path: &Path,
+    native_module_file: &str,
+    aot_artifact_path: &Path,
+) -> Result<()> {
+    install_extension_archive(paths, archive_path)?;
+    register_extension_aot_artifact(paths, native_module_file, aot_artifact_path)
+}
+
+#[cfg(feature = "extensions")]
+pub fn install_extension_bytes_with_aot(
+    paths: &PglitePaths,
+    bytes: &[u8],
+    native_module_file: &str,
+    aot_artifact_path: &Path,
+) -> Result<()> {
+    install_extension_bytes(paths, bytes)?;
+    register_extension_aot_artifact(paths, native_module_file, aot_artifact_path)
+}
+
+#[cfg(feature = "extensions")]
+fn normalize_extension_module_file(native_module_file: &str) -> Result<String> {
+    let path = Path::new(native_module_file);
+    ensure!(
+        path.is_relative(),
+        "extension native module path must be relative to lib/postgresql"
+    );
+    let stripped = path
+        .strip_prefix("lib/postgresql")
+        .unwrap_or(path)
+        .to_path_buf();
+    ensure!(
+        stripped
+            .components()
+            .all(|component| matches!(component, Component::Normal(_))),
+        "extension native module path must not contain separators, prefixes, or parent components"
+    );
+    let module_file = stripped
+        .to_str()
+        .context("extension native module path must be valid UTF-8")?;
+    ensure!(
+        !module_file.is_empty(),
+        "extension native module path must not be empty"
+    );
+    Ok(module_file.to_owned())
+}
+
+#[cfg(feature = "extensions")]
 pub(crate) fn install_bundled_extension_bytes(
     paths: &PglitePaths,
     sql_name: &str,

--- a/src/pglite/mod.rs
+++ b/src/pglite/mod.rs
@@ -29,6 +29,11 @@ pub use base::{
     install_extension_archive, install_extension_bytes, install_into, install_with_options,
     preload_runtime_module,
 };
+#[cfg(feature = "extensions")]
+pub use base::{
+    install_extension_archive_with_aot, install_extension_bytes_with_aot,
+    register_extension_aot_artifact,
+};
 pub use builder::PgliteBuilder;
 pub use client::{GlobalListenerHandle, ListenerHandle, Pglite, Transaction};
 pub use config::PostgresConfig;

--- a/src/pglite/postgres_mod.rs
+++ b/src/pglite/postgres_mod.rs
@@ -391,6 +391,16 @@ pub fn fs_trace_snapshot() -> FsTraceSnapshot {
 static WASIX_PROCESS_RUNTIME: OnceLock<std::result::Result<Arc<WasixProcessRuntime>, String>> =
     OnceLock::new();
 static SEEDED_SIDE_MODULES: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+#[cfg(feature = "extensions")]
+static CUSTOM_EXTENSION_SIDE_MODULES: OnceLock<Mutex<Vec<CustomExtensionSideModule>>> =
+    OnceLock::new();
+
+#[cfg(feature = "extensions")]
+#[derive(Debug, Clone)]
+struct CustomExtensionSideModule {
+    module_file: String,
+    artifact_name: String,
+}
 
 struct WasixProcessRuntime {
     tokio_runtime: Arc<TokioRuntime>,
@@ -799,6 +809,23 @@ impl virtual_fs::AsyncSeek for ProtocolStdioFile {
 }
 
 impl PostgresMod {
+    #[cfg(feature = "extensions")]
+    pub(crate) fn register_custom_extension_side_module(module_file: &str, artifact_name: String) {
+        let mut modules = CUSTOM_EXTENSION_SIDE_MODULES
+            .get_or_init(|| Mutex::new(Vec::new()))
+            .lock()
+            .expect("custom extension side module registry poisoned");
+        if modules.iter().any(|module| {
+            module.module_file == module_file && module.artifact_name == artifact_name
+        }) {
+            return;
+        }
+        modules.push(CustomExtensionSideModule {
+            module_file: module_file.to_owned(),
+            artifact_name,
+        });
+    }
+
     pub(crate) fn preload_module(module_path: &std::path::Path) -> Result<()> {
         let runtime_root = module_path
             .parent()
@@ -2590,6 +2617,26 @@ fn preload_installed_extension_side_modules(
             &format!("installed extension '{}'", extension.sql_name()),
         )?;
     }
+
+    let custom_modules = CUSTOM_EXTENSION_SIDE_MODULES
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .expect("custom extension side module registry poisoned")
+        .clone();
+    for custom in custom_modules {
+        let library = lib_dir.join(&custom.module_file);
+        if !library.exists() {
+            continue;
+        }
+        seed_side_module_cache(
+            runtime,
+            engine,
+            module_cache,
+            &library,
+            &custom.artifact_name,
+            &format!("custom extension '{}'", custom.module_file),
+        )?;
+    }
     Ok(())
 }
 
@@ -2598,7 +2645,7 @@ fn seed_side_module_cache(
     engine: &Engine,
     module_cache: &Arc<SharedCache>,
     library: &Path,
-    artifact_name: &'static str,
+    artifact_name: &str,
     label: &str,
 ) -> Result<()> {
     seed_wasix_module_cache(runtime, engine, module_cache, library, artifact_name, label)


### PR DESCRIPTION
## Summary

solves: https://github.com/f0rr0/oliphaunt/issues/35

The PR adds public APIs to install or register a custom Postgres extension archive together with a matching Wasmer AOT side-module artifact. It caches that artifact and seeds the WASIX module cache so custom WASIX native extensions can
 be loaded by CREATE EXTENSION in the headless/AOT runtime.

 Build/install the extension with the existing WASIX extension build flow, then package the installed extension files:

 ```sh
   tar -czf sqlite_fdw.tar.gz \
     lib/postgresql/sqlite_fdw.so \
     share/postgresql/extension/sqlite_fdw.control \
     share/postgresql/extension/sqlite_fdw--*.sql
 ```

 sqlite_fdw.so is the native side-module filename inside lib/postgresql, and sqlite_fdw.aot must be the Wasmer AOT artifact produced by serializing that exact .so with the same Wasmer/LLVM engine version used by pglite-oxide.

 ```rust
   let outcome = pglite_oxide::install_into(root.path())?;

   pglite_oxide::install_extension_archive_with_aot(
       &outcome.paths,
       "sqlite_fdw.tar.gz".as_ref(),
       "sqlite_fdw.so",
       "sqlite_fdw.aot".as_ref(),
   )?;

   let db = pglite_oxide::Pglite::new(outcome.paths)?;
   db.execute("CREATE EXTENSION sqlite_fdw;")?;
 ```

## Release Intent

- [x] Package/API/runtime change: PR title uses `feat:`, `fix:`, `perf:`, `refactor:`, `revert:`, or a breaking `!`.
- [ ] Docs/CI/repository-only change: no release intended.
- [ ] Asset/source-spine change: source pins/fingerprints are current and the Assets workflow will generate/test release artifacts.

## Verification

- [x] `scripts/validate.sh repo`
- [x] `scripts/validate.sh artifacts`
- [x] `scripts/validate.sh lint`
- [x] `scripts/validate.sh test`
- [x] `scripts/validate.sh package` when published package contents changed
- [x] `cargo deny check`
