### PR TITLE
fix: enable release workflow on canonical repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     name: Prepare release PR
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ github.repository == 'f0rr0/pglite-oxide' && inputs.operation == 'prepare-release-pr' }}
+    if: ${{ github.repository == 'f0rr0/oliphaunt' && inputs.operation == 'prepare-release-pr' }}
     environment: release-pr
     permissions:
       contents: write
@@ -95,7 +95,7 @@ jobs:
     name: Publish release
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    if: ${{ github.repository == 'f0rr0/pglite-oxide' && inputs.operation != 'prepare-release-pr' }}
+    if: ${{ github.repository == 'f0rr0/oliphaunt' && inputs.operation != 'prepare-release-pr' }}
     environment: ${{ inputs.operation == 'publish' && 'crates-io' || 'release-dry-run' }}
     permissions:
       actions: read


### PR DESCRIPTION
## Summary
- update release workflow job guards to allow runs in `f0rr0/oliphaunt`
- keep the existing operation gating for `prepare-release-pr`, `publish-dry-run`, and `publish`

## Root Cause
The skipped run https://github.com/f0rr0/oliphaunt/actions/runs/26923996956 never started any steps because both release jobs had a job-level repository guard for `f0rr0/pglite-oxide`. In this repository, `github.repository` is `f0rr0/oliphaunt`, so the guard evaluated false.

## Validation
- `actionlint .github/workflows/release.yml`
- `scripts/validate.sh workflows`
