### PR TITLE
docs: refresh oliphaunt docs site

### DIFF
--- a/src/docs/DESIGN_GROUNDING.md
+++ b/src/docs/DESIGN_GROUNDING.md
@@ -1,0 +1,108 @@
+# Oliphaunt Docs Design Grounding
+
+This file keeps the docs-site work scoped to the visual and UX foundation for
+`src/docs`.
+
+## Goal
+
+Build a striking, mobile-first docs foundation for Oliphaunt. The site should
+feel like a polished product surface for a polyglot embedded PostgreSQL library:
+SDK packages, runtime modes, tooling, maintainer paths, and equivalent examples
+across languages.
+
+Documentation completeness is secondary. Presentation, wayfinding, interaction,
+light/dark quality, and reusable docs affordances are the work.
+
+The active quality bar is Motion-level craft across the whole docs app, not just
+the first viewport. Every pass should re-check Motion, inspect rendered
+Oliphaunt pages, remove redundant or over-boxed UI, and keep code-looking text
+semantic: inline code for identifiers, real code blocks for commands/examples.
+
+## Motion Docs Takeaways
+
+Observed from `https://motion.dev/docs`, `/docs/react`, and deeper docs pages:
+
+- Oversized, confident page titles with tight copy and generous vertical rhythm.
+- Small monospace section labels, breadcrumbs, and version-like pills create a
+  product/manual feel.
+- The best visual texture is functional: line grids, diagonal hatching, compact
+  charts, code, and live-demo surfaces.
+- Cards are crisp and low-radius, often row-based rather than decorative.
+- Motion's docs home uses a dark product/manual surface, a compact technical
+  chart, a small set of primary route cards, and row-based secondary links; it
+  does not repeat full tutorial content on the landing page.
+- Mobile strips the experience down to strong title, intro, actions, and content;
+  side navigation should not dominate the first screen.
+- Animations should be restrained: subtle entrances, hover shifts, focus states,
+  and ambient technical motion that respects reduced-motion.
+- Code examples need to feel central and copyable, with clear language switching
+  for the same app flow.
+- Docs pages rely mostly on prose, rows, dividers, tables, and occasional code;
+  custom panels should be rare and earn their space.
+
+## Oliphaunt Foundation Principles
+
+- Keep the first screen product-like: Oliphaunt, embedded PostgreSQL, SDKs,
+  runtime modes, and a visible code/system artifact.
+- Use a balanced palette: ink/ivory neutrals with green as primary, amber/cyan
+  accents for state and language surfaces. Avoid a one-note green or slate UI.
+- Keep page sections unframed; cards are only for repeated items and tools.
+- Use 8px or smaller radii unless Fumadocs requires otherwise.
+- Prefer icons for recognisable tools/actions, with text for clear commands.
+- Make polyglot examples a first-class pattern, not an afterthought.
+- Maintain light and dark mode parity.
+- Preserve generated-content boundaries: edit presentation components, app
+  routes, theme CSS, and docs-app metadata; avoid changing generated targets.
+- Prefer divider-based row lists over nested cards when the user is choosing
+  among pages, SDKs, modes, or reference lookups.
+
+## Review Protocol
+
+- Revisit the docs app on mobile and desktop after substantial layout edits.
+- Run `pnpm --dir src/docs check` before handing off docs changes.
+- Use `pnpm --dir src/docs build` when changes touch route composition,
+  metadata, generated content, or Next.js boundaries.
+
+## Implementation Checklist
+
+- [x] Scope remains inside `src/docs`.
+- [ ] Landing page and every docs route reach Motion-level cleanliness on mobile
+  and desktop.
+- [x] Light and dark mode both have intentional contrast and texture.
+- [ ] Navigation and doc reading surfaces feel compact, clean, and polished on
+  every route.
+- [x] Polyglot code examples show the same flow across languages.
+- [ ] Reusable MDX components share a restrained row/table/prose visual language.
+- [x] Browser screenshots reviewed full-page on mobile and desktop after each
+  major slice.
+- [x] Motion reference pages reviewed during each active implementation turn.
+- [x] `pnpm --dir src/docs run check` or best available equivalent is
+  run before final handoff.
+
+## Current Slice Notes
+
+- Landing was reduced to hero, SDK choices, and reference paths; standalone
+  landing code comparisons and repeated runtime/docs/CTA sections were removed.
+- `/docs/start` was reduced to quickstart, first-query comparison, and next
+  steps; redundant outcome and verify panels were removed.
+- `/docs/learn` was converted from card-heavy maps/tabs to divider rows and
+  prose bullets.
+- `/docs/sdk` moved from card-heavy SDK chooser and runtime matrix to divider
+  rows. Focused audit improved `borderedPanels` from 35 to 13 and code blocks
+  from 7 to 0 on the SDK index.
+- Reference lookup/capability/extension/performance/release components moved
+  from boxed grids to divider rows. The audit metric now separates icon tiles
+  from real bordered panels.
+- This pass refreshed Motion `/docs`, `/docs/react`, `/docs/react-animation`,
+  `/docs/react-transitions`, and `/docs/react-layout-animations` screenshots.
+- Home now uses a dark Motion-like technical hero, a visible mobile product map,
+  and SDK rows instead of seven uneven SDK cards.
+- `/docs/start` now uses unboxed quickstart rows, flatter code blocks, and
+  row-based next steps. Focused audit improved `borderedPanels` from 8 to 2 on
+  desktop and mobile with no horizontal overflow.
+- Install prose no longer renders as terminal code in shared SDK summary
+  components; real install commands remain code blocks.
+- Next likely targets from full audit: React Native/native runtime panels,
+  embedded/mobile/SQLite/Tauri/WASM `gap-px bg-fd-border` grids, SDK index
+  content duplication, API reference identifier semantics, and tabbed polyglot
+  code affordances.

--- a/src/docs/content/learn/index.mdx
+++ b/src/docs/content/learn/index.mdx
@@ -13,25 +13,17 @@ behaves, and how to package the app without extra extension files.
 
 ## Suggested Paths
 
-<Tabs items={['Mobile apps', 'Desktop apps', 'SQLite migration']}>
-  <Tab value="Mobile apps">
-    Read [Embedded PostgreSQL](/docs/learn/embedded-postgres), then
-    [Mobile Stability](/docs/learn/mobile-stability). React Native developers
-    then read the [React Native architecture page](/docs/sdk/react-native/architecture)
-    before wiring background hooks or streaming large protocol responses.
-  </Tab>
-  <Tab value="Desktop apps">
-    Read [Native Runtime](/docs/learn/native-runtime) first. Tauri developers
-    then read [Tauri Usage](/docs/learn/tauri) and keep database ownership in
-    Rust state.
-  </Tab>
-  <Tab value="SQLite migration">
-    Read [Moving From SQLite](/docs/learn/sqlite-upgrade), then use
-    [Extensions](/docs/reference/extensions) and
-    [Performance](/docs/reference/performance) while sizing the app artifact
-    and benchmark plan.
-  </Tab>
-</Tabs>
+- **Mobile apps:** Read [Embedded PostgreSQL](/docs/learn/embedded-postgres),
+  then [Mobile Stability](/docs/learn/mobile-stability). React Native developers
+  then read the [React Native architecture page](/docs/sdk/react-native/architecture)
+  before wiring background hooks or streaming large protocol responses.
+- **Desktop apps:** Read [Native Runtime](/docs/learn/native-runtime) first.
+  Tauri developers then read [Tauri Usage](/docs/learn/tauri) and keep database
+  ownership in Rust state.
+- **SQLite migration:** Read [Moving From SQLite](/docs/learn/sqlite-upgrade),
+  then use [Extensions](/docs/reference/extensions) and
+  [Performance](/docs/reference/performance) while sizing the app artifact and
+  benchmark plan.
 
 ## What Learn Covers
 

--- a/src/docs/content/start/index.mdx
+++ b/src/docs/content/start/index.mdx
@@ -12,8 +12,6 @@ This page is the shortest tutorial path. Pick one app target, prove the runtime
 with one query, then move into the SDK, runtime, extension, or storage page that
 matches the next decision.
 
-<StartOutcome />
-
 ## Start In One App Target
 
 <QuickstartPath />
@@ -29,17 +27,6 @@ and close or detach through the SDK lifecycle.
 Use the SDK page for your app target when you need platform setup, native build
 consequences, lifecycle hooks, extension artifacts, backup, restore, and
 troubleshooting.
-
-## Install, Configure, Verify
-
-Keep these three checks close to your first integration because they confirm the
-SDK, package artifacts, and selected runtime all agree:
-
-<VerifyChecklist />
-
-React Native apps verify both JavaScript transport and native platform
-delegation. iOS/macOS verification flows through Swift; Android verification
-flows through Kotlin.
 
 ## After The First Query
 

--- a/src/docs/public/img/favicon.svg
+++ b/src/docs/public/img/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#102235"/>
+  <path d="M18 44V18h14c9 0 15 5 15 13s-6 13-15 13H18zm8-7h6c5 0 8-3 8-7s-3-7-8-7h-6v14z" fill="#8fd3c7"/>
+</svg>

--- a/src/docs/src/app/(home)/page.tsx
+++ b/src/docs/src/app/(home)/page.tsx
@@ -1,247 +1,188 @@
 import {
   ArrowRight,
-  CheckCircle2,
   Database,
-  GitBranch,
+  ListChecks,
   PackageCheck,
+  PlayCircle,
   Route,
   SearchCheck,
-  TerminalSquare,
 } from 'lucide-react';
 import Link from 'next/link';
-import { productPillars, runtimeModes, sdkSurfaces } from '@/lib/docs-data';
+import type { ReactNode } from 'react';
+import { runtimeModes, sdkSurfaces } from '@/lib/docs-data';
 
-const readerPaths = [
+const maintainerPaths = [
   {
-    label: 'Tutorial',
-    title: 'Run the first query',
-    href: '/docs/start',
-    description: 'Choose a platform SDK, open a root, run `SELECT 1`, and verify the runtime.',
+    title: 'Releases',
+    description: 'Version matrix, release notes, and artifact compatibility.',
+    href: '/docs/reference/releases',
+    icon: ListChecks,
+  },
+  {
+    title: 'Extensions',
+    description: 'SQL extension names, dependencies, targets, and packaging policy.',
+    href: '/docs/reference/extensions',
+    icon: SearchCheck,
+  },
+  {
+    title: 'API surfaces',
+    description: 'Language API maps plus the C ABI route for SDK bindings.',
+    href: '/docs/reference/api-reference',
     icon: Route,
   },
   {
-    label: 'How-to guides',
-    title: 'Build in your ecosystem',
-    href: '/docs/sdk',
-    description: 'Use Rust, Swift, Kotlin, React Native, TypeScript, WASM, or the C ABI.',
-    icon: PackageCheck,
-  },
-  {
-    label: 'Explanation',
-    title: 'Understand runtime shape',
-    href: '/docs/learn/native-runtime',
-    description: 'Compare direct, broker, server, roots, lifecycle, capabilities, and backup behavior.',
+    title: 'Performance',
+    description: 'Workload results, footprint notes, and claim evidence.',
+    href: '/docs/reference/performance',
     icon: Database,
-  },
-  {
-    label: 'Reference',
-    title: 'Look up exact support',
-    href: '/docs/reference',
-    description: 'Check modes, platform support, exact extensions, releases, and performance results.',
-    icon: SearchCheck,
   },
 ];
 
-const integrationPaths = [
-  {
-    title: 'Rust / Tauri',
-    packageName: 'oliphaunt',
-    install: 'cargo add oliphaunt',
-    verify: 'Direct, broker, or server mode',
-    href: '/docs/sdk/rust',
-  },
-  {
-    title: 'Swift / Apple',
-    packageName: 'Oliphaunt',
-    install: 'Add package in Xcode',
-    verify: 'App storage and lifecycle',
-    href: '/docs/sdk/swift',
-  },
-  {
-    title: 'Kotlin / Android',
-    packageName: 'dev.oliphaunt:oliphaunt',
-    install: 'id("dev.oliphaunt.android") + implementation("dev.oliphaunt:oliphaunt")',
-    verify: 'Gradle assets and ABI artifacts',
-    href: '/docs/sdk/kotlin',
-  },
-  {
-    title: 'React Native',
-    packageName: '@oliphaunt/react-native',
-    install: 'npx expo install @oliphaunt/react-native',
-    verify: 'Development build and JSI bytes',
-    href: '/docs/sdk/react-native',
-  },
-  {
-    title: 'TypeScript / Desktop JS',
-    packageName: '@oliphaunt/ts',
-    install: 'npm install @oliphaunt/ts',
-    verify: 'Helper assets and broker/server modes',
-    href: '/docs/sdk/typescript',
-  },
-  {
-    title: 'WASM / WASIX',
-    packageName: 'oliphaunt-wasix',
-    install: 'cargo add oliphaunt-wasix',
-    verify: 'WASIX assets and dump/restore',
-    href: '/docs/sdk/wasm',
-  },
+const productSignals = [
+  { label: 'SDK surfaces', value: '7' },
+  { label: 'Runtime families', value: '4' },
+  { label: 'First query', value: '1' },
 ];
+
+function ArrowLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <Link href={href} className="oliphaunt-arrow-link">
+      {children}
+      <ArrowRight className="size-4" />
+    </Link>
+  );
+}
 
 export default function HomePage() {
   return (
-    <main className="flex flex-1 flex-col">
-      <section className="oliphaunt-hero border-b">
-        <div className="mx-auto grid w-full max-w-6xl gap-8 px-6 py-14 lg:grid-cols-[0.92fr_1.08fr] lg:items-center lg:py-20">
-          <div>
-            <p className="mb-4 inline-flex items-center gap-2 rounded-md border bg-fd-card px-3 py-1 text-sm font-medium text-fd-muted-foreground">
-              <Database className="size-4 text-fd-primary" />
-              Embedded PostgreSQL for app developers
-            </p>
-            <h1 className="max-w-4xl text-4xl font-semibold leading-tight md:text-6xl">
-              Oliphaunt brings PostgreSQL into app-owned storage.
+    <main className="flex flex-1 flex-col overflow-x-clip">
+      <section className="oliphaunt-home-hero border-b">
+        <div className="mx-auto grid w-full max-w-7xl gap-10 px-5 pb-12 pt-10 sm:px-6 md:pt-16 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:items-center lg:pb-16">
+          <div className="min-w-0">
+            <div className="oliphaunt-rail-label">
+              <span>Oliphaunt</span>
+              <span>Docs</span>
+              <span>PostgreSQL in app storage</span>
+            </div>
+            <h1 className="mt-6 max-w-3xl text-6xl font-semibold leading-none text-fd-foreground sm:text-7xl lg:text-8xl">
+              Oliphaunt
             </h1>
-            <p className="mt-6 max-w-2xl text-lg leading-8 text-fd-muted-foreground">
-              Build local-first desktop, mobile, React Native, TypeScript, and
-              WASM apps with PostgreSQL behavior, explicit runtime modes, exact
-              extension packaging, and SDK-owned backup and restore.
+            <p className="mt-6 max-w-2xl text-lg leading-8 text-fd-muted-foreground sm:text-xl sm:leading-9">
+              Polyglot docs for embedded PostgreSQL SDKs, runtime modes, exact
+              extension packaging, and app-owned data movement.
             </p>
-            <div className="mt-8 flex flex-wrap gap-3">
-              <Link
-                href="/docs/start"
-                className="inline-flex items-center gap-2 rounded-md bg-fd-primary px-4 py-2 text-sm font-medium text-fd-primary-foreground transition-opacity hover:opacity-90"
-              >
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <Link href="/docs/start" className="oliphaunt-primary-action">
+                <PlayCircle className="size-4" />
                 Start with the docs
-                <ArrowRight className="size-4" />
               </Link>
-              <Link
-                href="/docs/sdk"
-                className="inline-flex items-center gap-2 rounded-md border bg-fd-card px-4 py-2 text-sm font-medium text-fd-foreground transition-colors hover:bg-fd-accent"
-              >
+              <Link href="/docs/sdk" className="oliphaunt-secondary-action">
+                <PackageCheck className="size-4" />
                 Choose an SDK
               </Link>
             </div>
-          </div>
-
-          <div className="oliphaunt-panel overflow-hidden rounded-lg border bg-fd-card">
-            <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-fd-muted/40 px-4 py-3">
-              <div className="inline-flex items-center gap-2 text-sm font-semibold">
-                <TerminalSquare className="size-4 text-fd-primary" />
-                First app paths
-              </div>
-              <span className="text-xs text-fd-muted-foreground">
-                same database flow, target-native package
-              </span>
-            </div>
-            <div className="grid gap-px bg-fd-border md:grid-cols-2 xl:grid-cols-3">
-              {integrationPaths.map((path) => (
-                <Link
-                  key={path.title}
-                  href={path.href}
-                  className="group flex min-w-0 flex-col bg-fd-background p-4 transition-colors hover:bg-fd-accent/70"
-                >
-                  <div className="flex min-w-0 items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <p className="text-sm font-semibold">{path.title}</p>
-                      <code className="mt-1 inline-block rounded border bg-fd-muted px-1.5 py-0.5 text-[0.72rem] text-fd-muted-foreground">
-                        {path.packageName}
-                      </code>
-                    </div>
-                    <ArrowRight className="mt-1 size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
-                  </div>
-                  <div className="mt-4 flex flex-1 flex-col justify-between gap-3">
-                    <div className="min-w-0">
-                      <p className="text-[0.7rem] font-medium uppercase text-fd-muted-foreground">
-                        Install
-                      </p>
-                      <code className="mt-1 block min-w-0 whitespace-normal break-words rounded border bg-fd-card px-2 py-1 text-xs">
-                        {path.install}
-                      </code>
-                    </div>
-                    <div className="min-w-0">
-                      <p className="text-[0.7rem] font-medium uppercase text-fd-muted-foreground">
-                        Verify
-                      </p>
-                      <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-                        {path.verify}
-                      </p>
-                    </div>
-                  </div>
-                </Link>
+            <div className="mt-8 grid max-w-xl grid-cols-3 border-y border-fd-border/70">
+              {productSignals.map((signal) => (
+                <div key={signal.label} className="min-w-0 border-e py-4 pe-4 last:border-e-0">
+                  <p className="text-2xl font-semibold leading-none text-fd-foreground">
+                    {signal.value}
+                  </p>
+                  <p className="mt-2 text-xs font-medium uppercase text-fd-muted-foreground">
+                    {signal.label}
+                  </p>
+                </div>
               ))}
             </div>
-            <div className="grid border-t text-sm sm:grid-cols-3">
-              {['Read capabilities', 'Use app-owned storage', 'Ship selected extensions'].map(
-                (item) => (
-                  <div
-                    key={item}
-                    className="flex items-center gap-3 border-b px-4 py-3 last:border-b-0 sm:border-b-0 sm:border-e sm:last:border-e-0"
-                  >
-                    <CheckCircle2 className="size-4 shrink-0 text-fd-primary" />
-                    <span className="text-sm">{item}</span>
-                  </div>
-                ),
-              )}
+          </div>
+
+          <div className="oliphaunt-product-visual" aria-label="Oliphaunt docs product map">
+            <div className="oliphaunt-product-visual__bar oliphaunt-product-visual__bar--desktop">
+              <span>Start path</span>
+              <span>SDK to runtime to verify</span>
             </div>
-            <div className="border-t bg-fd-muted/30 px-4 py-3">
-              <div className="grid gap-3 text-sm sm:grid-cols-3">
+            <div className="oliphaunt-product-visual__body">
+              <div className="oliphaunt-runtime-stack">
+                {runtimeModes.map((mode, index) => {
+                  const Icon = mode.icon;
+
+                  return (
+                    <Link key={mode.name} href={mode.href} className="oliphaunt-runtime-chip">
+                      <span className="oliphaunt-runtime-chip__index">
+                        {String(index + 1).padStart(2, '0')}
+                      </span>
+                      <Icon className="size-4" />
+                      <code className="min-w-0 truncate">{mode.name}</code>
+                    </Link>
+                  );
+                })}
+              </div>
+
+              <div className="oliphaunt-visual-footer">
                 <div>
-                  <p className="text-xs font-medium uppercase text-fd-muted-foreground">Root</p>
-                  <code className="mt-1 block text-fd-foreground">main.oliphaunt</code>
+                  <p>Choose</p>
+                  <span>SDK</span>
                 </div>
                 <div>
-                  <p className="text-xs font-medium uppercase text-fd-muted-foreground">Runtime</p>
-                  <code className="mt-1 block text-fd-foreground">nativeDirect</code>
+                  <p>Configure</p>
+                  <span>Runtime</span>
                 </div>
                 <div>
-                  <p className="text-xs font-medium uppercase text-fd-muted-foreground">
-                    First query
-                  </p>
-                  <code className="mt-1 block text-fd-foreground">SELECT 1</code>
+                  <p>Verify</p>
+                  <span>Query</span>
                 </div>
               </div>
-              <p className="mt-3 border-t pt-3 text-xs leading-5 text-fd-muted-foreground">
-                Building a new language binding? Start with the{' '}
-                <Link href="/docs/sdk/c-abi" className="font-medium text-fd-foreground underline">
-                  C ABI
-                </Link>
-                .
-              </p>
             </div>
           </div>
         </div>
       </section>
 
-      <section className="border-b bg-fd-card/40">
-        <div className="mx-auto w-full max-w-6xl px-6 py-12">
-          <div className="max-w-2xl">
-            <p className="oliphaunt-section-kicker">Docs path</p>
-            <h2 className="mt-2 text-2xl font-semibold">Use the docs by the job in front of you</h2>
-            <p className="mt-3 text-sm leading-6 text-fd-muted-foreground">
-              Start with the shortest query path, then move into platform guides,
-              runtime model pages, and exact lookup pages as the app integration grows.
+      <section className="mx-auto w-full max-w-7xl px-5 py-14 sm:px-6 lg:py-18">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:items-start">
+          <div>
+            <p className="oliphaunt-section-kicker">SDK surfaces</p>
+            <h2 className="mt-3 text-3xl font-semibold leading-tight md:text-5xl">
+              Choose by package and target.
+            </h2>
+            <p className="mt-4 max-w-xl text-sm leading-7 text-fd-muted-foreground">
+              Every SDK keeps the same database intent while matching its
+              platform package manager, lifecycle, concurrency model, and build
+              artifacts.
             </p>
           </div>
-          <div className="mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-4">
-            {readerPaths.map((path) => {
-              const Icon = path.icon;
+          <div className="divide-y border-y">
+            {sdkSurfaces.map((sdk) => {
+              const Icon = sdk.icon;
 
               return (
                 <Link
-                  key={path.title}
-                  href={path.href}
-                  className="group rounded-lg border bg-fd-background p-4 transition-colors hover:border-fd-primary/40 hover:bg-fd-accent/70"
+                  key={sdk.id}
+                  href={sdk.href}
+                  className="group grid min-w-0 gap-3 py-4 transition-colors hover:bg-fd-muted/35 sm:grid-cols-[auto_minmax(0,150px)_minmax(0,1fr)_minmax(0,160px)_24px] sm:items-start"
                 >
-                  <div className="flex items-start justify-between gap-3">
-                    <Icon className="size-5 text-fd-primary" />
-                    <ArrowRight className="size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
+                  <span className="oliphaunt-icon-tile">
+                    <Icon className="size-4" />
+                  </span>
+                  <div className="min-w-0">
+                    <h3 className="text-sm font-semibold">{sdk.title}</h3>
+                    <div className="mt-1">
+                      <code className="oliphaunt-inline-code">
+                        {sdk.packageName}
+                      </code>
+                    </div>
                   </div>
-                  <p className="mt-4 text-xs font-medium uppercase text-fd-muted-foreground">
-                    {path.label}
-                  </p>
-                  <h3 className="mt-1 text-base font-semibold">{path.title}</h3>
-                  <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
-                    {path.description}
-                  </p>
+                  <div className="min-w-0">
+                    <p className="text-sm leading-6 text-fd-muted-foreground">
+                      {sdk.target}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5 sm:justify-end">
+                    {sdk.modes.map((mode) => (
+                      <span key={mode} className="oliphaunt-mode-pill">
+                        {mode}
+                      </span>
+                    ))}
+                  </div>
+                  <ArrowRight className="hidden size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground sm:mt-1 sm:block" />
                 </Link>
               );
             })}
@@ -249,123 +190,40 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="mx-auto w-full max-w-6xl px-6 py-14">
-        <div className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
-          <div className="max-w-2xl">
-            <p className="oliphaunt-section-kicker">SDKs</p>
-            <h2 className="mt-2 text-2xl font-semibold">Start from the app you ship</h2>
-            <p className="mt-3 text-sm leading-6 text-fd-muted-foreground">
-              Each SDK uses the package manager, concurrency model, lifecycle, and
-              packaging rules developers already expect on that platform.
-            </p>
+      <section className="border-t bg-fd-card/35">
+        <div className="mx-auto w-full max-w-7xl px-5 py-12 sm:px-6">
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+            <div>
+              <p className="oliphaunt-section-kicker">Reference paths</p>
+              <h2 className="mt-3 text-3xl font-semibold leading-tight md:text-5xl">
+                Keep release and tooling details close.
+              </h2>
+              <p className="mt-4 max-w-lg text-sm leading-7 text-fd-muted-foreground">
+                Maintainers and SDK authors can jump straight to compatibility,
+                extension packaging, API surfaces, and performance evidence.
+              </p>
+            </div>
+            <div className="divide-y border-y">
+              {maintainerPaths.map((path) => {
+                const Icon = path.icon;
+
+                return (
+                  <Link key={path.title} href={path.href} className="oliphaunt-maintainer-row group">
+                    <span className="oliphaunt-icon-tile">
+                      <Icon className="size-4" />
+                    </span>
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold">{path.title}</p>
+                      <p className="mt-1 text-sm leading-6 text-fd-muted-foreground">
+                        {path.description}
+                      </p>
+                    </div>
+                    <ArrowRight className="size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
+                  </Link>
+                );
+              })}
+            </div>
           </div>
-          <Link
-            href="/docs/reference/sdk-products"
-            className="inline-flex items-center gap-2 text-sm font-medium text-fd-primary"
-          >
-            Compare SDKs
-            <ArrowRight className="size-4" />
-          </Link>
-        </div>
-        <div className="mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {sdkSurfaces.map((sdk) => {
-            const Icon = sdk.icon;
-
-            return (
-              <Link
-                key={sdk.title}
-                href={sdk.href}
-                className="group min-w-0 rounded-lg border bg-fd-card p-4 transition-colors hover:border-fd-primary/40 hover:bg-fd-accent/70"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <Icon className="size-5 text-fd-muted-foreground group-hover:text-fd-foreground" />
-                  <ArrowRight className="size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
-                </div>
-                <div className="mt-4 flex min-w-0 flex-wrap items-center gap-2">
-                  <h3 className="text-base font-semibold">{sdk.title}</h3>
-                  <code className="rounded border bg-fd-background px-1.5 py-0.5 text-[0.72rem] text-fd-muted-foreground">
-                    {sdk.packageName}
-                  </code>
-                </div>
-                <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">{sdk.target}</p>
-                <p className="mt-3 text-sm leading-6">{sdk.startWith}</p>
-                <code className="mt-3 block min-w-0 whitespace-normal break-words rounded border bg-fd-background px-2 py-1.5 text-xs text-fd-muted-foreground">
-                  {sdk.install}
-                </code>
-                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{sdk.owns}</p>
-                <div className="mt-3 border-t pt-3">
-                  <p className="text-[0.68rem] font-medium uppercase text-fd-muted-foreground">
-                    Verify first
-                  </p>
-                  <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-                    {sdk.verifyFirst}
-                  </p>
-                </div>
-              </Link>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="border-y bg-fd-muted/35">
-        <div className="mx-auto grid w-full max-w-6xl gap-4 px-6 py-12 md:grid-cols-2 lg:grid-cols-4">
-          {productPillars.map((pillar) => {
-            const Icon = pillar.icon;
-
-            return (
-              <div key={pillar.title} className="rounded-lg border bg-fd-background p-4">
-                <Icon className="mb-3 size-5 text-fd-primary" />
-                <h2 className="text-sm font-semibold">{pillar.title}</h2>
-                <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
-                  {pillar.description}
-                </p>
-              </div>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="mx-auto grid w-full max-w-6xl gap-8 px-6 py-14 lg:grid-cols-[0.85fr_1.15fr]">
-        <div>
-          <p className="oliphaunt-section-kicker">Runtime model</p>
-          <h2 className="mt-2 text-2xl font-semibold">Use the right PostgreSQL shape</h2>
-          <p className="mt-4 text-sm leading-6 text-fd-muted-foreground">
-            Oliphaunt makes runtime boundaries explicit. Pick the mode with the
-            concurrency, isolation, and compatibility your application uses.
-          </p>
-        </div>
-        <div className="grid gap-3">
-          {runtimeModes.map((mode) => (
-            <Link
-              key={mode.name}
-              href={mode.href}
-              className="grid gap-3 rounded-lg border bg-fd-card p-4 hover:bg-fd-accent md:grid-cols-[160px_1fr]"
-            >
-              <div>
-                <code className="text-sm font-semibold">{mode.name}</code>
-                <p className="mt-1 text-xs text-fd-muted-foreground">{mode.label}</p>
-              </div>
-              <p className="text-sm leading-6 text-fd-muted-foreground">{mode.useWhen}</p>
-            </Link>
-          ))}
-        </div>
-      </section>
-
-      <section className="border-t">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-10 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-sm font-semibold">Pick a platform path</p>
-            <p className="mt-1 text-sm text-fd-muted-foreground">
-              Start with the SDK page for your platform, then verify capabilities on the target.
-            </p>
-          </div>
-          <Link
-            href="/docs/start"
-            className="inline-flex items-center gap-2 rounded-md border bg-fd-card px-4 py-2 text-sm font-medium hover:bg-fd-accent"
-          >
-            Open Start
-            <GitBranch className="size-4" />
-          </Link>
         </div>
       </section>
     </main>

--- a/src/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/src/docs/src/app/docs/[[...slug]]/page.tsx
@@ -23,16 +23,59 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
 
   const MDX = page.data.body;
   const markdownUrl = getPageMarkdownUrl(page).url;
+  const compactHeader = page.slugs.length > 1;
+  const breadcrumbItems = [
+    { label: 'Docs', href: '/docs' },
+    ...page.slugs.map((slug, index) => ({
+      label: slug
+        .split('-')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' '),
+      href: `/docs/${page.slugs.slice(0, index + 1).join('/')}`,
+    })),
+  ];
 
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
-      <DocsTitle>{page.data.title}</DocsTitle>
-      <DocsDescription className="mb-0">{page.data.description}</DocsDescription>
-      <div className="flex flex-row gap-2 items-center border-b pb-6">
-        <MarkdownCopyButton markdownUrl={markdownUrl} />
-        <ViewOptionsPopover markdownUrl={markdownUrl} />
+    <DocsPage
+      toc={page.data.toc}
+      full={page.data.full}
+      breadcrumb={{ enabled: false }}
+      className="oliphaunt-doc-page"
+    >
+      <div
+        className={
+          compactHeader
+            ? 'oliphaunt-doc-header oliphaunt-doc-header--compact not-prose'
+            : 'oliphaunt-doc-header not-prose'
+        }
+      >
+        <nav className="oliphaunt-doc-header__path" aria-label="Breadcrumb">
+          <ol>
+            {breadcrumbItems.map((item, index) => {
+              const current = index === breadcrumbItems.length - 1;
+
+              return (
+                <li key={item.href}>
+                  {current ? (
+                    <span aria-current="page">{item.label}</span>
+                  ) : (
+                    <a href={item.href}>{item.label}</a>
+                  )}
+                </li>
+              );
+            })}
+          </ol>
+        </nav>
+        <DocsTitle className="oliphaunt-doc-title">{page.data.title}</DocsTitle>
+        <DocsDescription className="oliphaunt-doc-description">
+          {page.data.description}
+        </DocsDescription>
+        <div className="oliphaunt-doc-actions">
+          <MarkdownCopyButton markdownUrl={markdownUrl} />
+          <ViewOptionsPopover markdownUrl={markdownUrl} />
+        </div>
       </div>
-      <DocsBody>
+      <DocsBody className="oliphaunt-doc-body">
         <MDX
           components={getMDXComponents({
             // this allows you to link to other pages with relative file paths

--- a/src/docs/src/app/global.css
+++ b/src/docs/src/app/global.css
@@ -5,41 +5,43 @@
 @theme {
   --font-sans: var(--font-oliphaunt-sans);
   --font-mono: var(--font-oliphaunt-mono);
-  --color-fd-background: hsl(210, 24%, 98%);
-  --color-fd-foreground: hsl(218, 28%, 12%);
+  --color-fd-background: hsl(200, 20%, 98%);
+  --color-fd-foreground: hsl(176, 26%, 10%);
   --color-fd-card: hsl(0, 0%, 100%);
-  --color-fd-card-foreground: hsl(218, 28%, 12%);
+  --color-fd-card-foreground: hsl(176, 26%, 10%);
   --color-fd-popover: hsl(0, 0%, 100%);
-  --color-fd-popover-foreground: hsl(218, 28%, 12%);
-  --color-fd-primary: hsl(162, 72%, 29%);
+  --color-fd-popover-foreground: hsl(176, 26%, 10%);
+  --color-fd-primary: hsl(154, 76%, 27%);
   --color-fd-primary-foreground: hsl(0, 0%, 100%);
-  --color-fd-secondary: hsl(212, 22%, 94%);
-  --color-fd-secondary-foreground: hsl(218, 28%, 14%);
-  --color-fd-muted: hsl(210, 24%, 95%);
-  --color-fd-muted-foreground: hsl(218, 14%, 42%);
-  --color-fd-accent: hsl(204, 34%, 91%);
-  --color-fd-accent-foreground: hsl(218, 28%, 12%);
-  --color-fd-border: hsla(214, 20%, 72%, 0.55);
-  --color-fd-ring: hsl(162, 72%, 29%);
+  --color-fd-secondary: hsl(184, 21%, 92%);
+  --color-fd-secondary-foreground: hsl(176, 26%, 12%);
+  --color-fd-muted: hsl(190, 10%, 94%);
+  --color-fd-muted-foreground: hsl(178, 12%, 34%);
+  --color-fd-accent: hsl(39, 88%, 87%);
+  --color-fd-accent-foreground: hsl(176, 26%, 10%);
+  --color-fd-border: hsla(184, 13%, 42%, 0.26);
+  --color-fd-ring: hsl(154, 76%, 27%);
+  --color-oliphaunt-tech: hsl(189, 78%, 38%);
 }
 
 .dark {
-  --color-fd-background: hsl(218, 18%, 7%);
-  --color-fd-foreground: hsl(45, 20%, 92%);
-  --color-fd-card: hsl(218, 16%, 10%);
-  --color-fd-card-foreground: hsl(45, 20%, 92%);
-  --color-fd-popover: hsl(218, 16%, 9%);
-  --color-fd-popover-foreground: hsl(45, 20%, 92%);
-  --color-fd-primary: hsl(158, 66%, 58%);
-  --color-fd-primary-foreground: hsl(218, 26%, 8%);
-  --color-fd-secondary: hsl(217, 13%, 16%);
-  --color-fd-secondary-foreground: hsl(45, 20%, 92%);
-  --color-fd-muted: hsl(217, 13%, 14%);
-  --color-fd-muted-foreground: hsl(213, 11%, 68%);
-  --color-fd-accent: hsl(37, 20%, 18%);
-  --color-fd-accent-foreground: hsl(45, 22%, 92%);
-  --color-fd-border: hsla(212, 16%, 46%, 0.35);
-  --color-fd-ring: hsl(158, 66%, 58%);
+  --color-fd-background: hsl(168, 22%, 6%);
+  --color-fd-foreground: hsl(47, 24%, 92%);
+  --color-fd-card: hsl(168, 18%, 9%);
+  --color-fd-card-foreground: hsl(47, 24%, 92%);
+  --color-fd-popover: hsl(168, 20%, 7%);
+  --color-fd-popover-foreground: hsl(47, 24%, 92%);
+  --color-fd-primary: hsl(157, 74%, 56%);
+  --color-fd-primary-foreground: hsl(168, 26%, 7%);
+  --color-fd-secondary: hsl(176, 14%, 15%);
+  --color-fd-secondary-foreground: hsl(47, 24%, 92%);
+  --color-fd-muted: hsl(171, 13%, 13%);
+  --color-fd-muted-foreground: hsl(47, 10%, 66%);
+  --color-fd-accent: hsl(38, 86%, 57%);
+  --color-fd-accent-foreground: hsl(168, 26%, 7%);
+  --color-fd-border: hsla(166, 14%, 54%, 0.28);
+  --color-fd-ring: hsl(157, 74%, 56%);
+  --color-oliphaunt-tech: hsl(184, 82%, 58%);
 }
 
 html {
@@ -51,8 +53,8 @@ body {
   background:
     linear-gradient(
       180deg,
-      color-mix(in oklab, var(--color-fd-background), var(--color-fd-accent) 16%) 0,
-      var(--color-fd-background) 340px
+      color-mix(in oklab, var(--color-fd-background), var(--color-fd-primary) 5%) 0,
+      var(--color-fd-background) 420px
     ),
     var(--color-fd-background);
   color: var(--color-fd-foreground);
@@ -64,7 +66,6 @@ body {
 
 * {
   box-sizing: border-box;
-  letter-spacing: 0 !important;
 }
 
 *::before,
@@ -99,8 +100,7 @@ html > body[data-scroll-locked] {
   border-radius: 8px;
 }
 
-[data-card],
-.rounded-xl {
+[data-card] {
   border-radius: 8px;
 }
 
@@ -159,46 +159,61 @@ html > body[data-scroll-locked] {
 }
 
 .prose pre {
-  border: 1px solid var(--color-fd-border);
+  border: 0;
+  border-left: 2px solid color-mix(in oklab, var(--color-fd-primary), transparent 34%);
   border-radius: 8px;
-  box-shadow: inset 0 1px 0 color-mix(in oklab, var(--color-fd-card), transparent 85%);
+  background: color-mix(in oklab, var(--color-fd-card), var(--color-fd-background) 18%);
+  box-shadow: none;
 }
 
 .prose code:not(pre code) {
-  border: 1px solid color-mix(in oklab, var(--color-fd-border), transparent 25%);
-  border-radius: 5px;
-  background: color-mix(in oklab, var(--color-fd-muted), transparent 25%);
-  padding: 0.08rem 0.28rem;
+  border-radius: 4px;
+  background: color-mix(in oklab, var(--color-fd-muted), transparent 20%);
+  padding: 0.08rem 0.26rem;
   font-size: 0.88em;
 }
 
-.oliphaunt-hero {
+.oliphaunt-home-hero {
+  --color-fd-foreground: hsl(48, 24%, 94%);
+  --color-fd-muted-foreground: hsl(47, 8%, 66%);
+  --color-fd-card: hsl(166, 18%, 10%);
+  --color-fd-background: hsl(168, 22%, 7%);
+  --color-fd-border: hsla(160, 12%, 76%, 0.18);
+
+  position: relative;
+  isolation: isolate;
+  color: var(--color-fd-foreground);
   background:
     linear-gradient(
       90deg,
-      color-mix(in oklab, var(--color-fd-primary), transparent 92%) 1px,
+      color-mix(in oklab, var(--color-fd-border), transparent 58%) 1px,
       transparent 1px
     ),
     linear-gradient(
       180deg,
-      color-mix(in oklab, var(--color-fd-primary), transparent 94%) 1px,
+      color-mix(in oklab, var(--color-fd-border), transparent 68%) 1px,
       transparent 1px
     ),
-    linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--color-fd-card), var(--color-fd-accent) 24%),
-      var(--color-fd-background)
-    );
+    linear-gradient(180deg, hsl(168, 22%, 7%), hsl(166, 20%, 8%));
   background-size:
-    44px 44px,
-    44px 44px,
+    56px 56px,
+    56px 56px,
     auto;
 }
 
-.oliphaunt-panel {
-  box-shadow:
-    0 1px 0 color-mix(in oklab, var(--color-fd-card), transparent 80%) inset,
-    0 18px 50px color-mix(in oklab, var(--color-fd-foreground), transparent 93%);
+.oliphaunt-home-hero::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    repeating-linear-gradient(
+      115deg,
+      transparent 0 10px,
+      color-mix(in oklab, var(--color-fd-primary), transparent 94%) 10px 11px
+    ),
+    linear-gradient(180deg, transparent, var(--color-fd-background));
+  content: '';
+  mask-image: linear-gradient(180deg, black, transparent 76%);
 }
 
 .oliphaunt-section-kicker {
@@ -208,4 +223,547 @@ html > body[data-scroll-locked] {
   color: var(--color-fd-muted-foreground);
   font-size: 0.8125rem;
   font-weight: 500;
+}
+
+.oliphaunt-section-kicker::before {
+  width: 0.55rem;
+  height: 0.55rem;
+  border: 1px solid var(--color-fd-primary);
+  background: color-mix(in oklab, var(--color-fd-accent), transparent 35%);
+  content: '';
+}
+
+.oliphaunt-rail-label {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.oliphaunt-rail-label span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.oliphaunt-rail-label span:not(:last-child)::after {
+  color: color-mix(in oklab, var(--color-fd-primary), var(--color-fd-muted-foreground) 50%);
+  content: '/';
+}
+
+.oliphaunt-primary-action,
+.oliphaunt-secondary-action,
+.oliphaunt-arrow-link {
+  display: inline-flex;
+  min-height: 2.6rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.oliphaunt-primary-action {
+  border: 1px solid color-mix(in oklab, var(--color-fd-primary), black 8%);
+  background: var(--color-fd-primary);
+  color: var(--color-fd-primary-foreground);
+  padding: 0.55rem 1rem;
+}
+
+.oliphaunt-secondary-action {
+  border: 1px solid var(--color-fd-border);
+  background: color-mix(in oklab, var(--color-fd-card), transparent 8%);
+  color: var(--color-fd-foreground);
+  padding: 0.55rem 1rem;
+}
+
+.oliphaunt-arrow-link {
+  width: fit-content;
+  margin-top: 1.5rem;
+  color: var(--color-fd-foreground);
+}
+
+.oliphaunt-primary-action:hover,
+.oliphaunt-secondary-action:hover,
+.oliphaunt-arrow-link:hover {
+  transform: translateY(-1px);
+}
+
+.oliphaunt-primary-action:focus-visible,
+.oliphaunt-secondary-action:focus-visible,
+.oliphaunt-arrow-link:focus-visible,
+.oliphaunt-runtime-chip:focus-visible,
+.oliphaunt-maintainer-row:focus-visible {
+  outline: 2px solid var(--color-fd-ring);
+  outline-offset: 3px;
+}
+
+.oliphaunt-product-visual {
+  overflow: hidden;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--color-fd-card), transparent 3%);
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklab, white, transparent 82%),
+    0 24px 70px color-mix(in oklab, var(--color-fd-foreground), transparent 92%);
+}
+
+.oliphaunt-product-visual__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--color-fd-border);
+  background: color-mix(in oklab, var(--color-fd-muted), transparent 34%);
+  padding: 0.75rem 1rem;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.oliphaunt-product-visual__bar--desktop {
+  display: none;
+}
+
+.oliphaunt-product-visual__body {
+  display: grid;
+  gap: 0;
+  padding: 1rem;
+}
+
+.oliphaunt-runtime-stack {
+  display: grid;
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 8px;
+  background: var(--color-fd-border);
+}
+
+.oliphaunt-runtime-chip,
+.oliphaunt-maintainer-row {
+  display: grid;
+  min-width: 0;
+  align-items: center;
+  gap: 0.85rem;
+  border-radius: 8px;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease;
+}
+
+.oliphaunt-runtime-chip {
+  grid-template-columns: auto auto minmax(0, 1fr);
+  border: 0;
+  border-radius: 0;
+  background: color-mix(in oklab, var(--color-fd-background), transparent 12%);
+  padding: 0.85rem 0.9rem;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.oliphaunt-runtime-chip__index {
+  color: color-mix(in oklab, var(--color-fd-primary), var(--color-fd-foreground) 18%);
+  font-size: 0.7rem;
+}
+
+.oliphaunt-runtime-chip code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: inherit;
+  font-size: inherit;
+}
+
+.oliphaunt-runtime-chip:hover,
+.oliphaunt-maintainer-row:hover {
+  border-color: color-mix(in oklab, var(--color-fd-primary), var(--color-fd-border) 45%);
+  background: color-mix(in oklab, var(--color-fd-accent), var(--color-fd-card) 72%);
+}
+
+.oliphaunt-mode-pill {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--color-fd-card), transparent 12%);
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.68rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.oliphaunt-mode-pill {
+  padding: 0.32rem 0.48rem;
+}
+
+.oliphaunt-visual-footer {
+  display: grid;
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 8px;
+  background: var(--color-fd-border);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.oliphaunt-visual-footer > div {
+  min-width: 0;
+  background: color-mix(in oklab, var(--color-fd-background), transparent 15%);
+  padding: 0.8rem;
+}
+
+.oliphaunt-visual-footer p {
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.oliphaunt-visual-footer span {
+  display: block;
+  margin-top: 0.35rem;
+  overflow-wrap: anywhere;
+  color: var(--color-fd-foreground);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.oliphaunt-icon-tile {
+  display: inline-flex;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 8px;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in oklab, var(--color-fd-primary), transparent 84%),
+      color-mix(in oklab, var(--color-oliphaunt-tech), var(--color-fd-accent) 38%)
+    ),
+    var(--color-fd-background);
+  color: var(--color-fd-foreground);
+}
+
+.oliphaunt-maintainer-row {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  border-radius: 0;
+  padding: 1rem;
+}
+
+.oliphaunt-doc-page {
+  color: var(--color-fd-foreground);
+}
+
+.oliphaunt-doc-header {
+  position: relative;
+  isolation: isolate;
+  margin-bottom: 2.25rem;
+  border-bottom: 1px solid color-mix(in oklab, var(--color-fd-border), transparent 18%);
+  padding: 0 0 1.5rem;
+}
+
+.oliphaunt-doc-header::after {
+  content: none;
+}
+
+.oliphaunt-doc-header__path {
+  margin: 0;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.oliphaunt-doc-header__path ol {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.oliphaunt-doc-header__path li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.oliphaunt-doc-header__path li:not(:last-child)::after {
+  color: color-mix(in oklab, var(--color-fd-primary), var(--color-fd-muted-foreground) 50%);
+  content: '/';
+}
+
+.oliphaunt-doc-header__path a {
+  text-decoration: none;
+}
+
+.oliphaunt-doc-header__path a:hover {
+  color: var(--color-fd-foreground);
+}
+
+.oliphaunt-doc-title {
+  max-width: 50rem;
+  margin-top: 1rem !important;
+  margin-bottom: 0 !important;
+  font-size: 3rem !important;
+  line-height: 0.95 !important;
+}
+
+.oliphaunt-doc-header--compact {
+  padding-bottom: 1.35rem;
+}
+
+.oliphaunt-doc-header--compact .oliphaunt-doc-title {
+  font-size: 2.625rem !important;
+}
+
+.oliphaunt-doc-header--compact .oliphaunt-doc-description {
+  max-width: 50rem;
+}
+
+.oliphaunt-doc-description {
+  max-width: 42rem;
+  margin-top: 1.25rem !important;
+  margin-bottom: 0 !important;
+  color: var(--color-fd-muted-foreground);
+  font-size: 1.05rem !important;
+  line-height: 1.7 !important;
+}
+
+.oliphaunt-doc-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.25rem;
+}
+
+.oliphaunt-doc-body {
+  --tw-prose-body: var(--color-fd-foreground);
+  --tw-prose-headings: var(--color-fd-foreground);
+  --tw-prose-links: var(--color-fd-foreground);
+  --tw-prose-bold: var(--color-fd-foreground);
+  font-size: 0.98rem;
+  line-height: 1.75;
+}
+
+.oliphaunt-doc-body > :where(p, ul, ol) {
+  max-width: 42rem;
+}
+
+.oliphaunt-doc-body > :where(h2) {
+  margin-top: 2.75rem;
+  font-size: 1.75rem;
+  line-height: 1.15;
+}
+
+.oliphaunt-doc-body > :where(h3) {
+  font-size: 1.25rem;
+}
+
+.oliphaunt-mdx-panel {
+  border-color: color-mix(in oklab, var(--color-fd-border), transparent 10%);
+  background: var(--color-fd-card);
+  box-shadow: none;
+}
+
+.oliphaunt-mdx-panel__header {
+  background: color-mix(in oklab, var(--color-fd-muted), transparent 34%);
+}
+
+.oliphaunt-mdx-icon {
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in oklab, var(--color-fd-primary), transparent 86%),
+      color-mix(in oklab, var(--color-oliphaunt-tech), transparent 85%)
+    ),
+    var(--color-fd-background);
+}
+
+.oliphaunt-inline-code {
+  display: inline-block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  border-radius: 4px;
+  background: color-mix(in oklab, var(--color-fd-muted), transparent 18%);
+  padding: 0.08rem 0.3rem;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.78rem;
+}
+
+.oliphaunt-code-block {
+  overflow-x: auto;
+  margin: 0.5rem 0 0;
+  border: 0;
+  border-left: 2px solid color-mix(in oklab, var(--color-fd-primary), transparent 34%);
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--color-fd-card), var(--color-fd-background) 18%);
+  padding: 0.85rem 1rem;
+  color: var(--color-fd-foreground);
+  font-size: 0.78rem;
+  line-height: 1.7;
+}
+
+.oliphaunt-code-block code {
+  display: block;
+  min-width: max-content;
+  background: transparent;
+  padding: 0;
+}
+
+.oliphaunt-mdx-step-grid > div,
+.oliphaunt-mdx-step-grid > li,
+.oliphaunt-first-query .bg-fd-background {
+  min-width: 0;
+}
+
+.oliphaunt-first-query pre {
+  min-height: 9.5rem;
+  margin: 0;
+}
+
+.oliphaunt-query-example + .oliphaunt-query-example {
+  border-top: 1px solid var(--color-fd-border);
+}
+
+@media (max-width: 639px) {
+  .oliphaunt-home-hero > div {
+    gap: 1.75rem;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+  }
+
+  .oliphaunt-product-visual__body {
+    padding: 0.75rem;
+  }
+
+  .oliphaunt-visual-footer {
+    margin-top: 1px;
+  }
+
+  .oliphaunt-runtime-stack {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .oliphaunt-runtime-chip {
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.45rem;
+    padding: 0.55rem;
+    font-size: 0.68rem;
+  }
+
+  .oliphaunt-runtime-chip svg {
+    display: none;
+  }
+
+  .oliphaunt-product-visual {
+    margin-top: 0.5rem;
+  }
+
+  .oliphaunt-doc-header {
+    padding: 0 0 1.35rem;
+  }
+
+  .oliphaunt-doc-actions > * {
+    flex: 1 1 auto;
+  }
+
+  .oliphaunt-first-query pre {
+    min-height: 0;
+    max-height: 18rem;
+  }
+}
+
+@media (min-width: 640px) {
+  .oliphaunt-product-visual__bar--desktop {
+    display: flex;
+  }
+
+  .oliphaunt-doc-header {
+    padding-bottom: 2rem;
+  }
+
+  .oliphaunt-doc-header--compact {
+    padding-bottom: 1.7rem;
+  }
+
+  .oliphaunt-doc-title {
+    font-size: 4.25rem !important;
+  }
+
+  .oliphaunt-doc-header--compact .oliphaunt-doc-title {
+    font-size: 3.35rem !important;
+  }
+
+  .oliphaunt-doc-description {
+    font-size: 1.125rem !important;
+  }
+}
+
+@media (min-width: 1024px) {
+  .oliphaunt-doc-header {
+    padding-bottom: 2.4rem;
+  }
+
+  .oliphaunt-doc-header--compact {
+    padding-bottom: 2rem;
+  }
+
+  .oliphaunt-doc-title {
+    font-size: 5.35rem !important;
+  }
+
+  .oliphaunt-doc-header--compact .oliphaunt-doc-title {
+    font-size: 4rem !important;
+  }
+
+  .oliphaunt-product-visual__body {
+    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+  }
+
+  .oliphaunt-visual-footer {
+    border-left: 0;
+    border-radius: 0 8px 8px 0;
+  }
+
+  .oliphaunt-runtime-stack {
+    border-radius: 8px 0 0 8px;
+  }
+
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .oliphaunt-product-visual {
+    animation: oliphaunt-panel-rise 520ms ease-out both;
+  }
+
+}
+
+@keyframes oliphaunt-panel-rise {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/src/docs/src/components/oliphaunt.tsx
+++ b/src/docs/src/components/oliphaunt.tsx
@@ -22,15 +22,35 @@ import { runtimeModes, sdkSurfaces } from '@/lib/docs-data';
 
 function SurfaceIcon({ children }: { children: ReactNode }) {
   return (
-    <span className="not-prose inline-flex size-9 items-center justify-center rounded-md border bg-fd-background text-fd-muted-foreground">
+    <span className="oliphaunt-mdx-icon not-prose inline-flex size-9 items-center justify-center rounded-md border bg-fd-background text-fd-muted-foreground">
       {children}
     </span>
   );
 }
 
+function InlineCode({ children }: { children: ReactNode }) {
+  return <code className="oliphaunt-inline-code">{children}</code>;
+}
+
+function CodeBlock({ children }: { children: ReactNode }) {
+  return (
+    <pre className="oliphaunt-code-block">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+function InstallSnippet({ children }: { children: string }) {
+  if (/^(add|use)\b/iu.test(children)) {
+    return <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">{children}</p>;
+  }
+
+  return <CodeBlock>{children}</CodeBlock>;
+}
+
 export function SdkChooser() {
   return (
-    <div className="not-prose my-6 grid gap-3 md:grid-cols-2">
+    <div className="not-prose my-8 divide-y border-y">
       {sdkSurfaces.map((sdk) => {
         const Icon = sdk.icon;
 
@@ -38,46 +58,26 @@ export function SdkChooser() {
           <Link
             key={sdk.title}
             href={sdk.href}
-            className="group min-w-0 rounded-lg border bg-fd-card p-4 text-fd-card-foreground transition-colors hover:border-fd-primary/40 hover:bg-fd-accent/70"
+            className="group grid min-w-0 gap-3 py-4 text-fd-card-foreground transition-colors hover:bg-fd-muted/35 sm:grid-cols-[auto_minmax(0,240px)_minmax(0,1fr)_minmax(0,160px)_24px] sm:items-center"
           >
-            <div className="flex items-start justify-between gap-4">
-              <SurfaceIcon>
-                <Icon className="size-4" />
-              </SurfaceIcon>
-              <ArrowRight className="mt-2 size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
-            </div>
-            <div className="mt-4">
-              <div className="flex flex-wrap items-center gap-2">
-                <p className="text-sm font-semibold">{sdk.title}</p>
-                <code className="rounded border bg-fd-muted px-1.5 py-0.5 text-[0.72rem] text-fd-muted-foreground">
-                  {sdk.packageName}
-                </code>
-              </div>
-              <p className="mt-1 text-sm text-fd-muted-foreground">{sdk.target}</p>
-              <p className="mt-3 text-sm leading-6">{sdk.startWith}</p>
-              <code className="mt-3 block whitespace-normal break-words rounded border bg-fd-background px-2 py-1.5 text-xs text-fd-muted-foreground">
-                {sdk.install}
-              </code>
-              <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{sdk.owns}</p>
-              <div className="mt-3 border-t pt-3">
-                <p className="text-[0.68rem] font-medium uppercase text-fd-muted-foreground">
-                  Verify first
-                </p>
-                <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-                  {sdk.verifyFirst}
-                </p>
-              </div>
-              <div className="mt-3 flex flex-wrap gap-1.5">
-                {sdk.modes.map((mode) => (
-                  <span
-                    key={mode}
-                    className="rounded border bg-fd-background px-1.5 py-0.5 text-[0.7rem] font-medium text-fd-muted-foreground"
-                  >
-                    {mode}
-                  </span>
-                ))}
+            <SurfaceIcon>
+              <Icon className="size-4" />
+            </SurfaceIcon>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold">{sdk.title}</p>
+              <div className="mt-1">
+                <InlineCode>{sdk.packageName}</InlineCode>
               </div>
             </div>
+            <p className="text-sm leading-6 text-fd-muted-foreground">{sdk.target}</p>
+            <div className="flex flex-wrap gap-1.5">
+              {sdk.modes.map((mode) => (
+                <span key={mode} className="oliphaunt-mode-pill">
+                  {mode}
+                </span>
+              ))}
+            </div>
+            <ArrowRight className="hidden size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground sm:block" />
           </Link>
         );
       })}
@@ -134,9 +134,7 @@ export function ReactNativeApproachTable() {
               <p className="text-[0.68rem] font-medium uppercase text-fd-muted-foreground">
                 Install
               </p>
-              <code className="mt-1 block whitespace-normal break-words rounded border bg-fd-card px-2 py-1.5 text-xs">
-                {row.install}
-              </code>
+              <InstallSnippet>{row.install}</InstallSnippet>
             </div>
             <div className="mt-4">
               <p className="text-[0.68rem] font-medium uppercase text-fd-muted-foreground">
@@ -203,30 +201,30 @@ const learnRoutes = [
 
 export function LearnRouteMap() {
   return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="grid border-b bg-fd-muted/35 p-4 md:grid-cols-[220px_1fr] md:gap-6">
+    <div className="not-prose my-8">
+      <div className="grid gap-4 border-y py-4 md:grid-cols-[220px_1fr] md:gap-6">
         <div>
           <p className="text-sm font-semibold">Read by decision</p>
           <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
             Each page answers one production question after the first query works.
           </p>
         </div>
-        <div className="mt-4 grid gap-2 text-sm md:mt-0 md:grid-cols-3">
-          <div className="rounded-md border bg-fd-background p-3">
+        <div className="grid gap-4 text-sm sm:grid-cols-3">
+          <div>
             <p className="font-medium">Storage</p>
             <p className="mt-1 text-fd-muted-foreground">Root directory, WAL, backup.</p>
           </div>
-          <div className="rounded-md border bg-fd-background p-3">
+          <div>
             <p className="font-medium">Runtime</p>
             <p className="mt-1 text-fd-muted-foreground">Direct, broker, server, WASM.</p>
           </div>
-          <div className="rounded-md border bg-fd-background p-3">
+          <div>
             <p className="font-medium">App fit</p>
             <p className="mt-1 text-fd-muted-foreground">Mobile, Tauri, SQLite migration.</p>
           </div>
         </div>
       </div>
-      <div className="divide-y">
+      <div className="mt-4 divide-y border-y">
         {learnRoutes.map((route) => {
           const Icon = route.icon;
 
@@ -234,7 +232,7 @@ export function LearnRouteMap() {
             <Link
               key={route.href}
               href={route.href}
-              className="group grid gap-4 p-4 transition-colors hover:bg-fd-muted/35 md:grid-cols-[210px_1fr_1.2fr_24px] md:items-start"
+              className="group grid gap-3 py-4 transition-colors hover:bg-fd-muted/35 md:grid-cols-[210px_1fr_1.2fr_24px] md:items-start"
             >
               <div className="flex items-center gap-3">
                 <SurfaceIcon>
@@ -497,8 +495,8 @@ const referenceRows = [
 
 export function ReferenceLookup() {
   return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="border-b bg-fd-muted/35 p-4">
+    <div className="not-prose my-8">
+      <div className="border-y py-4">
         <div className="flex items-start gap-3">
           <SurfaceIcon>
             <FileSearch className="size-4" />
@@ -512,7 +510,7 @@ export function ReferenceLookup() {
           </div>
         </div>
       </div>
-      <div className="divide-y">
+      <div className="divide-y border-b">
         {referenceRows.map((row) => {
           const Icon = row.icon;
 
@@ -520,7 +518,7 @@ export function ReferenceLookup() {
             <Link
               key={row.href}
               href={row.href}
-              className="group grid gap-4 p-4 transition-colors hover:bg-fd-muted/35 md:grid-cols-[190px_1fr_180px_24px] md:items-start"
+              className="group grid gap-4 py-4 transition-colors hover:bg-fd-muted/35 md:grid-cols-[210px_1fr_180px_24px] md:items-start"
             >
               <div className="flex items-center gap-3">
                 <SurfaceIcon>
@@ -572,8 +570,8 @@ const releaseLookupRows = [
 
 export function ReleaseLookup() {
   return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="border-b bg-fd-muted/35 p-4">
+    <div className="not-prose my-8">
+      <div className="border-y py-4">
         <div className="flex items-start gap-3">
           <SurfaceIcon>
             <PackageCheck className="size-4" />
@@ -587,7 +585,7 @@ export function ReleaseLookup() {
           </div>
         </div>
       </div>
-      <div className="divide-y">
+      <div className="divide-y border-b">
         {releaseLookupRows.map((row) => {
           const Icon = row.icon;
 
@@ -595,7 +593,7 @@ export function ReleaseLookup() {
             <Link
               key={row.href}
               href={row.href}
-              className="group grid gap-4 p-4 transition-colors hover:bg-fd-muted/35 md:grid-cols-[250px_1fr_170px_24px] md:items-start"
+              className="group grid gap-4 py-4 transition-colors hover:bg-fd-muted/35 md:grid-cols-[250px_1fr_170px_24px] md:items-start"
             >
               <div className="flex items-center gap-3">
                 <SurfaceIcon>
@@ -630,7 +628,12 @@ const capabilityCards = [
   {
     title: 'Server mode',
     value: 'independent clients',
-    description: 'Use it for pools, ORMs, psql, pg_dump, and PostgreSQL connection strings.',
+    description: (
+      <>
+        Use it for pools, ORMs, <code>psql</code>, <code>pg_dump</code>, and PostgreSQL
+        connection strings.
+      </>
+    ),
     icon: ListChecks,
   },
   {
@@ -643,8 +646,8 @@ const capabilityCards = [
 
 export function CapabilitySnapshot() {
   return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="border-b bg-fd-muted/35 p-4">
+    <div className="not-prose my-8">
+      <div className="border-y py-4">
         <div className="flex items-start gap-3">
           <SurfaceIcon>
             <FileSearch className="size-4" />
@@ -657,20 +660,24 @@ export function CapabilitySnapshot() {
           </div>
         </div>
       </div>
-      <div className="grid gap-px bg-fd-border md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-5 border-b py-4 md:grid-cols-2 xl:grid-cols-4">
         {capabilityCards.map((card) => {
           const Icon = card.icon;
 
           return (
-            <div key={card.title} className="bg-fd-background p-4">
+            <div key={card.title} className="flex gap-3">
               <SurfaceIcon>
                 <Icon className="size-4" />
               </SurfaceIcon>
-              <p className="mt-4 text-sm font-semibold">{card.title}</p>
-              <code className="mt-2 inline-block rounded border bg-fd-card px-1.5 py-0.5 text-xs text-fd-muted-foreground">
-                {card.value}
-              </code>
-              <p className="mt-3 text-sm leading-6 text-fd-muted-foreground">{card.description}</p>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold">{card.title}</p>
+                <div className="mt-2">
+                  <InlineCode>{card.value}</InlineCode>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-fd-muted-foreground">
+                  {card.description}
+                </p>
+              </div>
             </div>
           );
         })}
@@ -682,7 +689,11 @@ export function CapabilitySnapshot() {
 const extensionFlow = [
   {
     title: 'Select SQL names',
-    description: 'Choose extension names such as `vector` in SDK configuration before opening.',
+    description: (
+      <>
+        Choose extension names such as <code>vector</code> in SDK configuration before opening.
+      </>
+    ),
   },
   {
     title: 'Resolve dependencies',
@@ -700,25 +711,29 @@ const extensionFlow = [
 
 export function ExtensionArtifactFlow() {
   return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="border-b bg-fd-muted/35 p-4">
+    <div className="not-prose my-8">
+      <div className="border-y py-4">
         <p className="text-sm font-semibold">Extension packaging flow</p>
         <p className="mt-1 text-sm leading-6 text-fd-muted-foreground">
           The selector is the SQL extension name. Build tooling handles target artifacts and
           dependency metadata.
         </p>
       </div>
-      <div className="grid gap-px bg-fd-border md:grid-cols-4">
+      <ol className="grid gap-5 border-b py-4 md:grid-cols-4">
         {extensionFlow.map((step, index) => (
-          <div key={step.title} className="bg-fd-background p-4">
+          <li key={step.title} className="flex gap-3">
             <span className="inline-flex size-7 items-center justify-center rounded-full border bg-fd-muted text-xs font-semibold text-fd-muted-foreground">
               {index + 1}
             </span>
-            <p className="mt-4 text-sm font-semibold">{step.title}</p>
-            <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">{step.description}</p>
-          </div>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold">{step.title}</p>
+              <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
+                {step.description}
+              </p>
+            </div>
+          </li>
         ))}
-      </div>
+      </ol>
     </div>
   );
 }
@@ -758,8 +773,8 @@ const performanceResults = [
 
 export function PerformanceResultsGrid() {
   return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="border-b bg-fd-muted/35 p-4">
+    <div className="not-prose my-8">
+      <div className="border-y py-4">
         <div className="flex items-start gap-3">
           <SurfaceIcon>
             <Gauge className="size-4" />
@@ -773,13 +788,13 @@ export function PerformanceResultsGrid() {
           </div>
         </div>
       </div>
-      <div className="grid gap-px bg-fd-border md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid gap-5 border-b py-4 md:grid-cols-2 xl:grid-cols-3">
         {performanceResults.map((item) => (
-          <div key={item.title} className="bg-fd-background p-4">
+          <div key={item.title}>
             <p className="text-sm font-semibold">{item.title}</p>
-            <code className="mt-2 inline-block rounded border bg-fd-card px-1.5 py-0.5 text-xs text-fd-muted-foreground">
-              {item.metrics}
-            </code>
+            <div className="mt-2">
+              <InlineCode>{item.metrics}</InlineCode>
+            </div>
             <p className="mt-3 text-sm leading-6 text-fd-muted-foreground">{item.description}</p>
           </div>
         ))}
@@ -804,7 +819,12 @@ const tauriModeCards = [
   {
     title: 'Clients need a URL',
     value: 'NativeServer',
-    description: 'Use server mode for pools, ORMs, psql, pg_dump, and independent sessions.',
+    description: (
+      <>
+        Use server mode for pools, ORMs, <code>psql</code>, <code>pg_dump</code>, and
+        independent sessions.
+      </>
+    ),
     icon: Route,
   },
 ];
@@ -836,9 +856,9 @@ export function TauriAppPattern() {
                 <Icon className="size-4" />
               </SurfaceIcon>
               <p className="mt-4 text-sm font-semibold">{card.title}</p>
-              <code className="mt-2 inline-block rounded border bg-fd-card px-1.5 py-0.5 text-xs text-fd-muted-foreground">
-                {card.value}
-              </code>
+              <div className="mt-2">
+                <InlineCode>{card.value}</InlineCode>
+              </div>
               <p className="mt-3 text-sm leading-6 text-fd-muted-foreground">
                 {card.description}
               </p>
@@ -848,13 +868,20 @@ export function TauriAppPattern() {
       </div>
       <div className="grid gap-3 border-t p-4 md:grid-cols-3">
         {[
-          'Expose narrow commands such as add_item or search_items.',
-          'Keep roots, locks, and handles out of the webview.',
-          'Use SDK backup and restore APIs for app import/export.',
+          {
+            key: 'commands',
+            label: (
+              <>
+              Expose narrow commands such as <code>add_item</code> or <code>search_items</code>.
+              </>
+            ),
+          },
+          { key: 'roots', label: 'Keep roots, locks, and handles out of the webview.' },
+          { key: 'backup', label: 'Use SDK backup and restore APIs for app import/export.' },
         ].map((item) => (
-          <div key={item} className="flex gap-2 text-sm leading-6">
+          <div key={item.key} className="flex gap-2 text-sm leading-6">
             <CheckCircle2 className="mt-1 size-4 shrink-0 text-fd-primary" />
-            <span>{item}</span>
+            <span>{item.label}</span>
           </div>
         ))}
       </div>
@@ -987,9 +1014,9 @@ export function WasmRuntimeMap() {
                 <Icon className="size-4" />
               </SurfaceIcon>
               <p className="mt-4 text-sm font-semibold">{card.title}</p>
-              <code className="mt-2 inline-block rounded border bg-fd-card px-1.5 py-0.5 text-xs text-fd-muted-foreground">
-                {card.value}
-              </code>
+              <div className="mt-2">
+                <InlineCode>{card.value}</InlineCode>
+              </div>
               <p className="mt-3 text-sm leading-6 text-fd-muted-foreground">
                 {card.description}
               </p>
@@ -1051,9 +1078,7 @@ export function WasmDataMovement() {
                 <td className="px-4 py-3 font-medium">{row.format}</td>
                 <td className="px-4 py-3 text-fd-muted-foreground">{row.use}</td>
                 <td className="px-4 py-3">
-                  <code className="rounded border bg-fd-background px-1.5 py-0.5 text-xs text-fd-muted-foreground">
-                    {row.api}
-                  </code>
+                  <InlineCode>{row.api}</InlineCode>
                 </td>
               </tr>
             ))}
@@ -1074,56 +1099,47 @@ export function SdkGuideSummary({ id }: { id: string }) {
   const Icon = sdk.icon;
 
   return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="border-b bg-fd-muted/35 p-4">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex min-w-0 items-start gap-3">
-            <SurfaceIcon>
-              <Icon className="size-4" />
-            </SurfaceIcon>
-            <div className="min-w-0">
-              <p className="text-sm font-semibold">{sdk.title} setup path</p>
-              <p className="mt-1 text-sm leading-6 text-fd-muted-foreground">{sdk.startWith}</p>
-            </div>
+    <div className="not-prose my-8">
+      <div className="flex flex-col gap-4 border-y py-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <SurfaceIcon>
+            <Icon className="size-4" />
+          </SurfaceIcon>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold">{sdk.title} setup path</p>
+            <p className="mt-1 text-sm leading-6 text-fd-muted-foreground">{sdk.startWith}</p>
           </div>
-          <div className="flex shrink-0 flex-col gap-2 sm:items-end">
-            <code className="w-fit rounded border bg-fd-background px-2 py-1 text-xs text-fd-muted-foreground">
-              {sdk.packageName}
-            </code>
-            <div className="flex flex-wrap gap-1.5 sm:justify-end">
-              {sdk.modes.map((mode) => (
-                <span
-                  key={mode}
-                  className="rounded border bg-fd-background px-1.5 py-0.5 text-[0.7rem] font-medium text-fd-muted-foreground"
-                >
-                  {mode}
-                </span>
-              ))}
-            </div>
+        </div>
+        <div className="flex shrink-0 flex-col gap-2 sm:items-end">
+          <InlineCode>{sdk.packageName}</InlineCode>
+          <div className="flex flex-wrap gap-1.5 sm:justify-end">
+            {sdk.modes.map((mode) => (
+              <span key={mode} className="oliphaunt-mode-pill">
+                {mode}
+              </span>
+            ))}
           </div>
         </div>
       </div>
-      <div className="grid gap-px bg-fd-border md:grid-cols-2 xl:grid-cols-4">
-        <div className="bg-fd-background p-4">
+      <div className="grid gap-5 border-b py-4 md:grid-cols-2 xl:grid-cols-4">
+        <div>
           <p className="text-xs font-medium uppercase text-fd-muted-foreground">Install</p>
-          <code className="mt-2 block whitespace-normal break-words rounded border bg-fd-card px-2 py-1.5 text-xs">
-            {sdk.install}
-          </code>
+          <InstallSnippet>{sdk.install}</InstallSnippet>
         </div>
-        <div className="bg-fd-background p-4">
+        <div>
           <p className="text-xs font-medium uppercase text-fd-muted-foreground">Target</p>
           <p className="mt-2 text-sm leading-6">{sdk.target}</p>
         </div>
-        <div className="bg-fd-background p-4">
+        <div>
           <p className="text-xs font-medium uppercase text-fd-muted-foreground">SDK owns</p>
           <p className="mt-2 text-sm leading-6">{sdk.owns}</p>
         </div>
-        <div className="bg-fd-background p-4">
+        <div>
           <p className="text-xs font-medium uppercase text-fd-muted-foreground">Verify first</p>
           <p className="mt-2 text-sm leading-6">{sdk.verifyFirst}</p>
         </div>
       </div>
-      <div className="grid gap-3 border-t p-4 md:grid-cols-3">
+      <div className="grid gap-3 py-4 md:grid-cols-3">
         {sdk.guideOutcomes.map((outcome) => (
           <div key={outcome} className="flex gap-2 text-sm leading-6">
             <CheckCircle2 className="mt-1 size-4 shrink-0 text-fd-primary" />
@@ -1273,31 +1289,33 @@ export function SdkGuideProof({ id }: { id: string }) {
   }
 
   return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="border-b bg-fd-muted/35 p-4">
+    <div className="not-prose my-8">
+      <div className="border-y py-4">
         <p className="text-sm font-semibold">This guide is complete when</p>
         <p className="mt-1 text-sm leading-6 text-fd-muted-foreground">
           Use these checks before moving from a first query to application code.
         </p>
       </div>
-      <div className="grid gap-px bg-fd-border md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-4 border-b py-4 md:grid-cols-2 xl:grid-cols-4">
         {checks.map((check) => (
-          <div key={check.title} className="bg-fd-background p-4">
-            <CheckCircle2 className="mb-3 size-4 text-fd-primary" />
-            <p className="text-sm font-semibold">{check.title}</p>
-            <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">{check.description}</p>
+          <div key={check.title} className="flex gap-3">
+            <CheckCircle2 className="mt-1 size-4 shrink-0 text-fd-primary" />
+            <div>
+              <p className="text-sm font-semibold">{check.title}</p>
+              <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
+                {check.description}
+              </p>
+            </div>
           </div>
         ))}
       </div>
-      <div className="border-t p-4">
-        <Link
-          href={`${sdk.href}/api-reference`}
-          className="group inline-flex items-center gap-2 text-sm font-medium text-fd-foreground"
-        >
-          Open the {sdk.title} API map
-          <ArrowRight className="size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
-        </Link>
-      </div>
+      <Link
+        href={`${sdk.href}/api-reference`}
+        className="group inline-flex items-center gap-2 py-4 text-sm font-medium text-fd-foreground"
+      >
+        Open the {sdk.title} API map
+        <ArrowRight className="size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
+      </Link>
     </div>
   );
 }
@@ -1315,8 +1333,8 @@ export function SdkLanding({ id }: { id: string }) {
   const extraHref = id === 'react-native' ? `${sdk.href}/architecture` : undefined;
 
   return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="grid border-b bg-fd-muted/35 p-4 md:grid-cols-[1.25fr_0.75fr] md:gap-6">
+    <div className="not-prose my-8">
+      <div className="grid gap-6 border-y py-4 md:grid-cols-[1.25fr_0.75fr]">
         <div className="min-w-0">
           <div className="flex items-start gap-3">
             <SurfaceIcon>
@@ -1329,74 +1347,64 @@ export function SdkLanding({ id }: { id: string }) {
           </div>
           <p className="mt-4 text-sm leading-6">{sdk.startWith}</p>
         </div>
-        <div className="mt-4 min-w-0 rounded-md border bg-fd-background p-3 md:mt-0">
+        <div className="min-w-0">
           <p className="text-xs font-medium uppercase text-fd-muted-foreground">Install</p>
-          <code className="mt-2 block whitespace-normal break-words rounded border bg-fd-card px-2 py-1.5 text-xs">
-            {sdk.install}
-          </code>
-          <code className="mt-2 block w-fit rounded border bg-fd-card px-2 py-1 text-xs text-fd-muted-foreground">
-            {sdk.packageName}
-          </code>
+          <InstallSnippet>{sdk.install}</InstallSnippet>
+          <div className="mt-2">
+            <InlineCode>{sdk.packageName}</InlineCode>
+          </div>
         </div>
       </div>
-      <div className="grid gap-px bg-fd-border md:grid-cols-3">
-        <div className="bg-fd-background p-4">
+      <div className="grid gap-5 border-b py-4 md:grid-cols-3">
+        <div>
           <p className="text-xs font-medium uppercase text-fd-muted-foreground">SDK owns</p>
           <p className="mt-2 text-sm leading-6">{sdk.owns}</p>
         </div>
-        <div className="bg-fd-background p-4">
+        <div>
           <p className="text-xs font-medium uppercase text-fd-muted-foreground">Modes</p>
           <div className="mt-2 flex flex-wrap gap-1.5">
             {sdk.modes.map((mode) => (
-              <span
-                key={mode}
-                className="rounded border bg-fd-card px-1.5 py-0.5 text-[0.7rem] font-medium text-fd-muted-foreground"
-              >
+              <span key={mode} className="oliphaunt-mode-pill">
                 {mode}
               </span>
             ))}
           </div>
         </div>
-        <div className="bg-fd-background p-4">
+        <div>
           <p className="text-xs font-medium uppercase text-fd-muted-foreground">Verify first</p>
           <p className="mt-2 text-sm leading-6">{sdk.verifyFirst}</p>
         </div>
       </div>
-      <div className="grid gap-3 border-t p-4 md:grid-cols-3">
-        <Link
-          href={guideHref}
-          className="group rounded-md border bg-fd-background p-3 transition-colors hover:bg-fd-muted/45"
-        >
-          <p className="text-sm font-semibold">Build guide</p>
-          <p className="mt-1 text-sm leading-6 text-fd-muted-foreground">
-            Install, open, configure, select extensions, and verify lifecycle.
-          </p>
-          <ArrowRight className="mt-3 size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
-        </Link>
-        <Link
-          href={apiHref}
-          className="group rounded-md border bg-fd-background p-3 transition-colors hover:bg-fd-muted/45"
-        >
-          <p className="text-sm font-semibold">API map</p>
-          <p className="mt-1 text-sm leading-6 text-fd-muted-foreground">
-            Find the public surface for open, query, lifecycle, capabilities, and backup.
-          </p>
-          <ArrowRight className="mt-3 size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
-        </Link>
-        <Link
-          href={extraHref ?? '/docs/reference/capabilities'}
-          className="group rounded-md border bg-fd-background p-3 transition-colors hover:bg-fd-muted/45"
-        >
-          <p className="text-sm font-semibold">
-            {extraHref ? 'Architecture' : 'Capabilities'}
-          </p>
-          <p className="mt-1 text-sm leading-6 text-fd-muted-foreground">
-            {extraHref
+      <div className="divide-y border-b">
+        {[
+          {
+            href: guideHref,
+            title: 'Build guide',
+            description: 'Install, open, configure, select extensions, and verify lifecycle.',
+          },
+          {
+            href: apiHref,
+            title: 'API map',
+            description: 'Find the public surface for open, query, lifecycle, capabilities, and backup.',
+          },
+          {
+            href: extraHref ?? '/docs/reference/capabilities',
+            title: extraHref ? 'Architecture' : 'Capabilities',
+            description: extraHref
               ? 'Understand the React Native, Swift, Kotlin, TurboModule, and JSI boundary.'
-              : 'Check mode, streaming, extension, backup, restore, and client-session support.'}
-          </p>
-          <ArrowRight className="mt-3 size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
-        </Link>
+              : 'Check mode, streaming, extension, backup, restore, and client-session support.',
+          },
+        ].map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="group grid gap-2 py-4 transition-colors hover:bg-fd-muted/35 sm:grid-cols-[180px_1fr_24px]"
+          >
+            <p className="text-sm font-semibold">{item.title}</p>
+            <p className="text-sm leading-6 text-fd-muted-foreground">{item.description}</p>
+            <ArrowRight className="hidden size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground sm:mt-1 sm:block" />
+          </Link>
+        ))}
       </div>
     </div>
   );
@@ -1418,14 +1426,19 @@ export function QuickstartPath() {
     },
     {
       title: 'Run SQL and verify capabilities',
-      description: 'Run `SELECT 1`, read `capabilities()`, and create only the extensions selected for the app artifact.',
+      description: (
+        <>
+          Run <code>SELECT 1</code>, read <code>capabilities()</code>, and create only the
+          extensions selected for the app artifact.
+        </>
+      ),
     },
   ];
 
   return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="border-b bg-fd-muted/40 p-4">
-        <div className="flex items-center gap-3">
+    <div className="not-prose my-8">
+      <div className="border-y py-4">
+        <div className="flex items-start gap-3">
           <PlayCircle className="size-5 text-fd-primary" />
           <div>
             <p className="text-sm font-semibold">Start in one app target</p>
@@ -1436,17 +1449,20 @@ export function QuickstartPath() {
           </div>
         </div>
       </div>
-      <div className="grid gap-px bg-fd-border md:grid-cols-4">
+      <ol className="divide-y border-b">
         {steps.map((step, index) => (
-          <div key={step.title} className="bg-fd-background p-4">
-            <span className="inline-flex size-7 items-center justify-center rounded-full border bg-fd-muted text-xs font-semibold text-fd-muted-foreground">
-              {index + 1}
+          <li
+            key={step.title}
+            className="grid gap-3 py-4 sm:grid-cols-[3rem_minmax(0,190px)_minmax(0,1fr)]"
+          >
+            <span className="text-xs font-medium text-fd-muted-foreground">
+              {String(index + 1).padStart(2, '0')}
             </span>
-            <p className="mt-4 text-sm font-semibold">{step.title}</p>
-            <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">{step.description}</p>
-          </div>
+            <p className="text-sm font-semibold">{step.title}</p>
+            <p className="text-sm leading-6 text-fd-muted-foreground">{step.description}</p>
+          </li>
         ))}
-      </div>
+      </ol>
     </div>
   );
 }
@@ -1465,7 +1481,12 @@ export function StartOutcome() {
     },
     {
       title: 'One query verified',
-      description: '`SELECT 1`, `capabilities()`, and selected extensions prove the runtime path.',
+      description: (
+        <>
+          <code>SELECT 1</code>, <code>capabilities()</code>, and selected extensions prove the
+          runtime path.
+        </>
+      ),
       icon: ClipboardCheck,
     },
     {
@@ -1476,7 +1497,7 @@ export function StartOutcome() {
   ];
 
   return (
-    <div className="not-prose my-6 rounded-lg border bg-fd-card p-4">
+    <div className="oliphaunt-mdx-panel not-prose my-6 rounded-lg border bg-fd-card p-4">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <p className="text-sm font-semibold">Finish this page with a working app path</p>
@@ -1488,12 +1509,12 @@ export function StartOutcome() {
           Tutorial
         </span>
       </div>
-      <div className="mt-4 grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+      <ul className="mt-4 grid gap-px overflow-hidden rounded-md border bg-fd-border md:grid-cols-2 xl:grid-cols-4">
         {outcomes.map((outcome) => {
           const Icon = outcome.icon;
 
           return (
-            <div key={outcome.title} className="flex min-w-0 gap-3 rounded-md border bg-fd-background p-3">
+            <li key={outcome.title} className="flex min-w-0 gap-3 bg-fd-background p-3">
               <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-md border bg-fd-card text-fd-muted-foreground">
                 <Icon className="size-4" />
               </span>
@@ -1503,48 +1524,94 @@ export function StartOutcome() {
                   {outcome.description}
                 </p>
               </div>
-            </div>
+            </li>
           );
         })}
-      </div>
+      </ul>
     </div>
   );
 }
 
-export function FirstQueryFlow() {
-  return (
-    <div className="not-prose my-6 overflow-hidden rounded-lg border bg-fd-card">
-      <div className="grid border-b md:grid-cols-[220px_1fr]">
-        <div className="border-b bg-fd-muted/40 p-4 md:border-b-0 md:border-e">
-          <p className="text-sm font-semibold">First query shape</p>
-          <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
-            The syntax changes by SDK. The application flow stays recognizable.
-          </p>
-        </div>
-        <pre className="overflow-x-auto p-4 text-sm leading-6">
-          <code>{`const db = await Oliphaunt.open({
+const firstQueryExamples = [
+  {
+    language: 'TypeScript',
+    packageName: '@oliphaunt/ts',
+    code: `const db = await Oliphaunt.open({
   root: 'main.oliphaunt',
   engine: 'nativeDirect',
   extensions: ['vector'],
 });
 
-const result = await db.query('SELECT 1::text AS value');
-const value = result.getText(0, 'value');
+const rows = await db.query('select 1 as ready');
+await db.close();`,
+  },
+  {
+    language: 'Rust',
+    packageName: 'oliphaunt',
+    code: `let db = Oliphaunt::builder()
+    .root("main.oliphaunt")
+    .mode(RuntimeMode::NativeDirect)
+    .extension("vector")
+    .open()
+    .await?;
 
-await db.close();`}</code>
-        </pre>
-      </div>
-      <div className="grid gap-px bg-fd-border text-sm md:grid-cols-5">
-        {['Choose storage', 'Select mode', 'Select extensions', 'Open and query', 'Close or detach'].map(
-          (item, index) => (
-            <div key={item} className="bg-fd-background p-3">
+db.query("select 1 as ready").await?;
+db.close().await?;`,
+  },
+  {
+    language: 'Swift',
+    packageName: 'Oliphaunt',
+    code: `let db = try await Oliphaunt.open(
+  root: .appStorage("main.oliphaunt"),
+  mode: .nativeDirect,
+  extensions: ["vector"]
+)
+
+try await db.query("select 1 as ready")
+try await db.close()`,
+  },
+];
+
+export function FirstQueryFlow() {
+  return (
+    <div className="oliphaunt-first-query not-prose my-8">
+      <div className="grid gap-4 border-y py-4 md:grid-cols-[210px_1fr]">
+        <div>
+          <p className="text-sm font-semibold">First query shape</p>
+          <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
+            Same storage, mode, extension, query, and lifecycle path across SDK syntax.
+          </p>
+        </div>
+        <ol className="grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-5">
+          {['Storage', 'Mode', 'Extensions', 'Query', 'Lifecycle'].map((item, index) => (
+            <li key={item}>
               <span className="text-xs font-medium text-fd-muted-foreground">
                 {String(index + 1).padStart(2, '0')}
               </span>
               <p className="mt-1 font-medium">{item}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
+      <div className="divide-y border-b">
+        {firstQueryExamples.map((example) => (
+          <div
+            key={example.language}
+            className="oliphaunt-query-example grid gap-3 py-5 md:grid-cols-[170px_minmax(0,1fr)]"
+          >
+            <div className="min-w-0">
+              <div className="min-w-0">
+                <p className="text-sm font-semibold">{example.language}</p>
+                <div className="mt-1">
+                  <InlineCode>{example.packageName}</InlineCode>
+                </div>
+              </div>
             </div>
-          ),
-        )}
+            <pre className="oliphaunt-code-block mt-0">
+              <code>{example.code}</code>
+            </pre>
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -1583,7 +1650,7 @@ const startNextSteps = [
 
 export function StartNextSteps() {
   return (
-    <div className="not-prose my-6 grid gap-3 md:grid-cols-2">
+    <div className="not-prose my-8 divide-y border-y">
       {startNextSteps.map((step) => {
         const Icon = step.icon;
 
@@ -1591,21 +1658,19 @@ export function StartNextSteps() {
           <Link
             key={step.href}
             href={step.href}
-            className="group min-w-0 rounded-lg border bg-fd-card p-4 transition-colors hover:border-fd-primary/40 hover:bg-fd-accent/70"
+            className="group grid min-w-0 gap-3 py-4 transition-colors hover:bg-fd-muted/35 sm:grid-cols-[auto_150px_minmax(0,1fr)_24px] sm:items-start"
           >
-            <div className="flex items-start justify-between gap-4">
-              <SurfaceIcon>
-                <Icon className="size-4" />
-              </SurfaceIcon>
-              <ArrowRight className="mt-2 size-4 shrink-0 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground" />
+            <SurfaceIcon>
+              <Icon className="size-4" />
+            </SurfaceIcon>
+            <div className="min-w-0">
+              <p className="text-xs font-medium uppercase text-fd-muted-foreground">
+                {step.label}
+              </p>
+              <p className="mt-1 text-sm font-semibold">{step.title}</p>
             </div>
-            <p className="mt-4 text-xs font-medium uppercase text-fd-muted-foreground">
-              {step.label}
-            </p>
-            <p className="mt-1 text-sm font-semibold">{step.title}</p>
-            <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
-              {step.description}
-            </p>
+            <p className="text-sm leading-6 text-fd-muted-foreground">{step.description}</p>
+            <ArrowRight className="hidden size-4 text-fd-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-fd-foreground sm:mt-1 sm:block" />
           </Link>
         );
       })}
@@ -1627,7 +1692,12 @@ export function VerifyChecklist() {
     },
     {
       title: 'Verify',
-      description: '`SELECT 1`, `capabilities()`, and selected extensions behave on the target.',
+      description: (
+        <>
+          <code>SELECT 1</code>, <code>capabilities()</code>, and selected extensions behave on
+          the target.
+        </>
+      ),
       icon: ClipboardCheck,
     },
   ];
@@ -1699,21 +1769,21 @@ export function ShipChecklist() {
 
 export function ModeMatrix() {
   return (
-    <div className="not-prose my-6 grid gap-3">
+    <div className="not-prose my-8 divide-y border-y">
       {runtimeModes.map((mode) => {
         const Icon = mode.icon;
 
         return (
           <div
             key={mode.name}
-            className="grid gap-4 rounded-lg border bg-fd-card p-4 md:grid-cols-[180px_1fr_1fr] md:items-start"
+            className="grid gap-4 py-4 md:grid-cols-[190px_1fr_1fr] md:items-start"
           >
             <div className="flex items-center gap-3">
               <SurfaceIcon>
                 <Icon className="size-4" />
               </SurfaceIcon>
               <div>
-                <code className="text-sm font-semibold">{mode.name}</code>
+                <InlineCode>{mode.name}</InlineCode>
                 <p className="mt-1 text-xs text-fd-muted-foreground">{mode.label}</p>
               </div>
             </div>

--- a/src/docs/src/lib/layout.shared.tsx
+++ b/src/docs/src/lib/layout.shared.tsx
@@ -9,6 +9,22 @@ export function baseOptions(): BaseLayoutProps {
     },
     links: [
       {
+        text: 'Start',
+        url: '/docs/start',
+      },
+      {
+        text: 'SDKs',
+        url: '/docs/sdk',
+      },
+      {
+        text: 'Learn',
+        url: '/docs/learn',
+      },
+      {
+        text: 'Reference',
+        url: '/docs/reference',
+      },
+      {
         text: 'GitHub',
         url: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
         external: true,

--- a/src/docs/tools/check-docs-product.mjs
+++ b/src/docs/tools/check-docs-product.mjs
@@ -746,10 +746,8 @@ function assertStartPageCoverage() {
   }
   const markdown = readText(startPath);
   const requiredComponents = [
-    'StartOutcome',
     'QuickstartPath',
     'FirstQueryFlow',
-    'VerifyChecklist',
     'StartNextSteps',
   ];
   for (const component of requiredComponents) {
@@ -760,7 +758,6 @@ function assertStartPageCoverage() {
   const requiredHeadings = [
     'Start In One App Target',
     'First Query Shape',
-    'Install, Configure, Verify',
     'After The First Query',
   ];
   let previousHeadingIndex = -1;


### PR DESCRIPTION
## Summary

- Refreshes the Oliphaunt docs homepage and doc layout styling under `src/docs`.
- Adds design grounding notes and a public favicon asset.
- Simplifies selected start/learn MDX content and updates docs product checks for the refreshed structure.

## Impact

This keeps the docs-site presentation and validation helpers aligned with the squashed Oliphaunt release branch layout, where the docs app now lives at `src/docs`.

## Validation

- `git diff --check`
- `pnpm install --frozen-lockfile --filter @oliphaunt/docs...`
- `pnpm --dir src/docs check`
