### PR TITLE
fix(ci): cancel pr runs on close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
-run-name: CI / ${{ github.event_name == 'pull_request' && format('PR {0}', github.event.pull_request.number) || github.ref_name }}
+run-name: CI / ${{ github.event_name == 'pull_request' && format('PR {0}', github.event.number) || github.ref_name }}
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
   merge_group:
     types: [checks_requested]
   push:
@@ -51,7 +52,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -76,6 +77,7 @@ defaults:
 jobs:
   affected:
     name: Plan
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:

--- a/src/runtimes/liboliphaunt/wasix/moon.yml
+++ b/src/runtimes/liboliphaunt/wasix/moon.yml
@@ -91,8 +91,6 @@ tasks:
       - "liboliphaunt-wasix:check"
       - "source-inputs:source-fetch-wasix-runtime"
     inputs:
-      - "/.github/actions/setup-wasmer-llvm/**/*"
-      - "/.github/workflows/ci.yml"
       - "/Cargo.lock"
       - "/Cargo.toml"
       - "/rust-toolchain.toml"
@@ -125,8 +123,6 @@ tasks:
     deps:
       - "liboliphaunt-wasix:runtime-portable"
     inputs:
-      - "/.github/actions/setup-wasmer-llvm/**/*"
-      - "/.github/workflows/ci.yml"
       - "/Cargo.lock"
       - "/Cargo.toml"
       - "/rust-toolchain.toml"

--- a/tools/policy/assertions/assert-ci-workflows.mjs
+++ b/tools/policy/assertions/assert-ci-workflows.mjs
@@ -145,9 +145,30 @@ const ciHeadRef = 'ref: ${{ github.event.pull_request.head.sha || github.sha }}'
 const mobileArtifactRef = 'ref: ${{ needs.resolve.outputs.sha }}';
 
 requireText(ciPath, 'name: CI');
+requireText(
+  ciPath,
+  "run-name: CI / ${{ github.event_name == 'pull_request' && format('PR {0}', github.event.number) || github.ref_name }}",
+  'CI run name must use the top-level pull_request event number',
+);
 if (/^name: Builds$/m.test(ci)) {
   fail('CI workflow must not be renamed to Builds');
 }
+requireText(
+  ciPath,
+  'types: [opened, synchronize, reopened, closed]',
+  'CI pull_request trigger must include closed so PR close/merge cancels in-progress PR CI',
+);
+requireText(
+  ciPath,
+  "group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.ref }}",
+  'CI concurrency must group pull_request runs by PR number so closed events cancel the active PR run',
+);
+assertBlockContains(
+  ciBlocks,
+  'affected',
+  "if: ${{ github.event_name != 'pull_request' || github.event.action != 'closed' }}",
+  'closed pull_request events must only cancel the prior run and must not execute CI planning',
+);
 rejectText(ciPath, 'artifact-builders');
 rejectText(ciPath, 'python3 - <<');
 if (beforePushTrigger.includes('paths:')) {

--- a/tools/policy/check-moon-product-graph.mjs
+++ b/tools/policy/check-moon-product-graph.mjs
@@ -107,11 +107,7 @@ function assertTaskInput(tasks, projectId, taskId, expectedInput) {
   if (!task) {
     throw new Error(`missing moon task ${projectId}:${taskId}`);
   }
-  const inputs = [
-    ...Object.keys(task.inputFiles ?? {}),
-    ...Object.keys(task.inputGlobs ?? {}),
-    ...(task.inputs ?? []).map((input) => input.file ?? input.glob).filter(Boolean),
-  ];
+  const inputs = taskInputs(task);
   if (!inputs.includes(expectedInput)) {
     throw new Error(
       `${projectId}:${taskId}: expected input '${expectedInput}', got [${inputs.sort().join(', ')}]`,
@@ -254,18 +250,38 @@ function assertNoDefaultInputs(tasks, projectId, taskId) {
   }
 }
 
-function rejectTaskInput(tasks, projectId, taskId, rejectedInput) {
+function rejectTaskInput(tasks, projectId, taskId, rejectedInput, reason = 'is not allowed') {
   const task = tasks[projectId]?.[taskId];
   if (!task) {
     throw new Error(`missing moon task ${projectId}:${taskId}`);
   }
-  const inputs = [
+  const inputs = taskInputs(task);
+  if (inputs.includes(rejectedInput)) {
+    throw new Error(`${projectId}:${taskId}: input '${rejectedInput}' ${reason}`);
+  }
+}
+
+function taskInputs(task) {
+  return [
     ...Object.keys(task.inputFiles ?? {}),
     ...Object.keys(task.inputGlobs ?? {}),
     ...(task.inputs ?? []).map((input) => input.file ?? input.glob).filter(Boolean),
   ];
-  if (inputs.includes(rejectedInput)) {
-    throw new Error(`${projectId}:${taskId}: input '${rejectedInput}' would include generated moon cache state`);
+}
+
+function assertArtifactTasksDoNotDependOnCiImplementation(tasks) {
+  for (const [projectId, projectTasks] of Object.entries(tasks)) {
+    for (const [taskId, task] of Object.entries(projectTasks ?? {})) {
+      if (!(task.tags ?? []).includes('artifact')) {
+        continue;
+      }
+      const ciInputs = taskInputs(task).filter((input) => input.startsWith('/.github/'));
+      if (ciInputs.length > 0) {
+        throw new Error(
+          `${projectId}:${taskId}: artifact tasks must model product source/toolchain inputs, not CI implementation inputs [${ciInputs.sort().join(', ')}]`,
+        );
+      }
+    }
   }
 }
 
@@ -289,6 +305,7 @@ function assertTaskOutput(tasks, projectId, taskId, expectedOutput) {
 const projects = parseProjects();
 const tasks = parseTasks();
 assertShellTasksUseBash(tasks);
+assertArtifactTasksDoNotDependOnCiImplementation(tasks);
 const requiredProjects = new Set([
   'repo',
   'ci-workflows',
@@ -792,7 +809,20 @@ assertTaskTags(tasks, 'liboliphaunt-wasix', 'release-assets', ['artifact', 'rele
 assertTaskCache(tasks, 'liboliphaunt-wasix', 'runtime-portable', false);
 assertTaskCache(tasks, 'liboliphaunt-wasix', 'runtime-aot', false);
 assertTaskCache(tasks, 'liboliphaunt-wasix', 'release-assets', false);
-assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-portable', '/.github/workflows/ci.yml');
+rejectTaskInput(
+  tasks,
+  'liboliphaunt-wasix',
+  'runtime-portable',
+  '/.github/actions/setup-wasmer-llvm/**/*',
+  'is CI implementation detail, not a WASIX runtime source input',
+);
+rejectTaskInput(
+  tasks,
+  'liboliphaunt-wasix',
+  'runtime-portable',
+  '/.github/workflows/ci.yml',
+  'is CI implementation detail, not a WASIX runtime source input',
+);
 assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-portable', '/src/runtimes/liboliphaunt/wasix/**/*');
 assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-portable', '/src/postgres/versions/18/**/*');
 assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-portable', '/src/sources/toolchains/**/*');
@@ -800,7 +830,20 @@ assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-portable', '/src/sources/t
 assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-portable', '/src/sources/third-party/wasix/**/*');
 assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-portable', '/src/shared/extension-runtime-contract/**/*');
 assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-portable', '/tools/xtask/**/*');
-assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-aot', '/.github/workflows/ci.yml');
+rejectTaskInput(
+  tasks,
+  'liboliphaunt-wasix',
+  'runtime-aot',
+  '/.github/actions/setup-wasmer-llvm/**/*',
+  'is CI implementation detail, not a WASIX AOT source input',
+);
+rejectTaskInput(
+  tasks,
+  'liboliphaunt-wasix',
+  'runtime-aot',
+  '/.github/workflows/ci.yml',
+  'is CI implementation detail, not a WASIX AOT source input',
+);
 assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-aot', '/src/runtimes/liboliphaunt/wasix/**/*');
 assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-aot', '/src/postgres/versions/18/**/*');
 assertTaskInput(tasks, 'liboliphaunt-wasix', 'runtime-aot', '/src/sources/toolchains/**/*');


### PR DESCRIPTION
## Summary
- trigger CI on pull_request.closed so closing or merging a PR starts a same-group cancellation run
- group pull_request CI by top-level PR number instead of github.ref, because merged closed events use the base branch ref
- skip the real CI Plan job on closed PR events and assert the workflow invariants in policy

## Validation
- git diff --check
- bun tools/policy/assertions/assert-ci-workflows.mjs
- moon run ci-workflows:check repo:ci-policy repo:tooling

## Notes
- Cancelled obsolete PR #52 CI run 27743326432 after merge.