### PR TITLE
ci: remove weekly CI schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ on:
           - android
           - ios
           - both
-  schedule:
-    - cron: "41 4 * * 1"
-
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
- remove the weekly scheduled CI cron trigger
- keep PR, merge queue, main push, and manual CI triggers unchanged

## Validation
- bun tools/policy/assertions/assert-ci-workflows.mjs
- bash tools/policy/check-workflows.sh
- python3 tools/policy/check-release-policy.py