### PR TITLE
fix(ci): pin standalone android e2e emulator api

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -110,6 +110,8 @@ jobs:
           find target/mobile-build/react-native/android -maxdepth 2 -type f -print
 
       - name: Start Android emulator
+        env:
+          OLIPHAUNT_ANDROID_EMULATOR_API: "35"
         run: tools/dev/start-android-emulator-ci.sh
 
       - name: Run Android installed-app E2E

--- a/tools/policy/assertions/assert-ci-workflows.mjs
+++ b/tools/policy/assertions/assert-ci-workflows.mjs
@@ -308,6 +308,7 @@ rejectText(mobilePath, 'workflows: ["Builds"]');
 rejectText(mobilePath, 'artifact_builders_succeeded');
 requireText(mobilePath, 'name: E2E');
 requireText(mobilePath, 'BUILD_GATE_JOB: Builds');
+requireText(mobilePath, 'OLIPHAUNT_ANDROID_EMULATOR_API: "35"');
 requireText(mobilePath, 'bun .github/scripts/resolve-mobile-e2e.mjs');
 requireText(mobilePath, 'bun .github/scripts/check-ci-gate.mjs allow-skipped');
 assertBlockContains(mobileBlocks, 'required', 'name: E2E', 'E2E gate job must be named E2E');


### PR DESCRIPTION
## Summary
- pin the standalone mobile E2E Android emulator to API 35, matching the inline CI E2E lane
- add a CI workflow policy assertion so the standalone E2E workflow keeps that pin

## Root cause
The failed E2E workflow run used the standalone mobile-e2e workflow on main. Its Android startup step inherited the emulator script default API 36, then failed because the runner could not install system-images;android-36;google_atd;x86_64. Main CI stayed green because its inline Android E2E job already sets OLIPHAUNT_ANDROID_EMULATOR_API=35.

## Validation
- bun tools/policy/assertions/assert-ci-workflows.mjs
- bash tools/policy/check-workflows.sh
- python3 tools/policy/check-release-policy.py