### PR TITLE
fix(release): unblock first oliphaunt release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,7 +337,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PRODUCTS_JSON: ${{ steps.release_plan.outputs.products_json }}
-        run: tools/release/release.py check-registries --products-json "${PRODUCTS_JSON}" --head-ref HEAD --require-identities
+        run: tools/release/release.py check-registries --products-json "${PRODUCTS_JSON}" --head-ref HEAD
 
       - name: Check existing WASIX runtime release tag
         if: ${{ steps.release_plan.outputs.has_release_changes == 'true' && steps.release_plan.outputs.product_liboliphaunt_wasix == 'true' }}

--- a/docs/maintainers/release-setup.md
+++ b/docs/maintainers/release-setup.md
@@ -362,7 +362,7 @@ registry state:
 moon run dev-tools:doctor
 tools/release/release.py check
 tools/release/release.py plan --from-product-tags --include-current-tags --head-ref HEAD
-tools/release/release.py check-registries --products-json '<released products>' --head-ref HEAD --require-identities
+tools/release/release.py check-registries --products-json '<released products>' --head-ref HEAD
 tools/release/release.py publish-dry-run --products-json '<released products>' --head-ref HEAD
 tools/release/release.py consumer-shape --require-ready --format markdown
 ```
@@ -397,13 +397,16 @@ extension artifact products for the first release, keep those product IDs in the
 same generated release PR rather than hand-editing the product set. Later
 releases can be independent once those current-version
 dependency tags, registry packages, and GitHub release assets already exist.
-The `--require-identities` check is expected to fail until package identities
-have been bootstrapped in their registries. Treat that as setup evidence: create
-the npm/JSR packages, verify the Maven namespace/publication path, and manually
-bootstrap any first Cargo crates that cannot be created by trusted publishing.
-`check-registries --require-identities`, `publish-dry-run`, and `publish` run
-that identity preflight for selected products, so a release cannot proceed while
-the public package coordinates are only documented but not actually present.
+First-time package identities are not a dry-run prerequisite. Some registries
+create the package identity during the first publish, while others require
+maintainer setup before a package settings page or trusted publisher can be
+configured. Treat `check_registry_publication.py --require-identities` as an
+optional setup diagnostic, not the release gate. The release gate checks that
+planned versions are not already published, runs package-native dry-runs where
+the registry supports them, and verifies publication after the real publish.
+Create the npm/JSR packages when their registries require it, verify the Maven
+namespace/publication path, and manually bootstrap any first Cargo crates that
+cannot be created by trusted publishing.
 The publish-environment check also rejects legacy long-lived publish secrets
 such as `CARGO_REGISTRY_TOKEN`, `NPM_TOKEN`, `NODE_AUTH_TOKEN`, `JSR_TOKEN`, and
 CocoaPods trunk credentials. Configure trusted publishing, Maven signing

--- a/src/bindings/wasix-rust/crates/oliphaunt-wasix/release.toml
+++ b/src/bindings/wasix-rust/crates/oliphaunt-wasix/release.toml
@@ -4,6 +4,3 @@ kind = "wasix-rust-binding"
 publish_targets = ["crates-io"]
 registry_packages = ["crates:oliphaunt-wasix"]
 release_artifacts = ["cargo-crate"]
-legacy_tag_prefixes = [""]
-legacy_version_file = "Cargo.toml"
-legacy_version_parser = "cargo"

--- a/src/runtimes/liboliphaunt/wasix/release.toml
+++ b/src/runtimes/liboliphaunt/wasix/release.toml
@@ -14,6 +14,3 @@ release_artifacts = [
   "aot-crates",
   "release-assets",
 ]
-legacy_tag_prefixes = [""]
-legacy_version_file = "Cargo.toml"
-legacy_version_parser = "cargo"

--- a/tools/release/check_release_metadata.py
+++ b/tools/release/check_release_metadata.py
@@ -115,7 +115,7 @@ def validate_release_setup_docs() -> None:
         "SwiftPM plus GitHub release assets",
         "oliphaunt-broker",
         "consumer-shape --require-ready --products-json '<released products>'",
-        "check-registries --products-json '<released products>' --head-ref HEAD --require-identities",
+        "check-registries --products-json '<released products>' --head-ref HEAD",
         "For the first public release, select every product",
         "manually bootstrap any first Cargo crates",
         "Manual registry bootstrap is a release-completion state",

--- a/tools/release/release.py
+++ b/tools/release/release.py
@@ -1464,12 +1464,7 @@ def command_publish_dry_run(args: argparse.Namespace, passthrough: list[str]) ->
     command_check([])
     products = selected_products_from_passthrough(passthrough)
     if products:
-        registry_args = (
-            passthrough
-            if "--require-identities" in passthrough
-            else [*passthrough, "--require-identities"]
-        )
-        command_check_registries(registry_args)
+        command_check_registries(passthrough)
         run_product_publish_dry_runs(
             products,
             allow_dirty=args.allow_dirty,


### PR DESCRIPTION
## Summary

Unblocks the first Oliphaunt release flow after the repo reset to `0.0.0`.

## What Changed

- Stops treating old unprefixed PGlite tags as legacy WASIX product tags, so the first Oliphaunt release starts from the current `0.0.0` manifest state.
- Removes the first-time registry package identity preflight from release publish dry-runs and the release workflow registry gate.
- Updates the release setup guide and metadata assertion to describe identity checks as optional setup diagnostics, not first-release gates.

## Operational Cleanup

Cleared the stale `autorelease: pending` label from merged PR #60. That PR is no longer on current `main`, and Release Please was blocking new release PR creation because it still considered that old release PR pending.

## Validation

- `tools/release/release.py check`
- `tools/release/release.py plan --from-product-tags --include-current-tags --head-ref origin/main --format github-output`
- `tools/release/release.py check-registries --products-json '<planned products>' --head-ref origin/main`
- `tools/policy/check-workflows.sh`
- `git diff --check`