### PR TITLE
fix(release): sync extension evidence after asset inputs

### DIFF
--- a/src/extensions/evidence/runs/2026-06-07-transitional-catalog-smoke.json
+++ b/src/extensions/evidence/runs/2026-06-07-transitional-catalog-smoke.json
@@ -514,7 +514,7 @@
     }
   ],
   "schema": "oliphaunt-extension-evidence-v1",
-  "sourceDigest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f",
+  "sourceDigest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610",
   "sourceDigestInputs": [
     "src/postgres/versions/18/source.toml",
     "src/extensions/catalog/extensions.promoted.toml",

--- a/src/extensions/generated/docs/extension-evidence.json
+++ b/src/extensions/generated/docs/extension-evidence.json
@@ -20,7 +20,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -56,7 +56,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -92,7 +92,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -128,7 +128,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -164,7 +164,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -200,7 +200,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -236,7 +236,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -272,7 +272,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -308,7 +308,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -344,7 +344,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -380,7 +380,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -416,7 +416,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -452,7 +452,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -488,7 +488,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -524,7 +524,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -560,7 +560,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -596,7 +596,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -632,7 +632,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -668,7 +668,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -704,7 +704,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -740,7 +740,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -776,7 +776,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -812,7 +812,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -848,7 +848,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -884,7 +884,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -920,7 +920,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -956,7 +956,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -992,7 +992,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1028,7 +1028,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1064,7 +1064,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1100,7 +1100,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1136,7 +1136,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1172,7 +1172,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1208,7 +1208,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1244,7 +1244,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1280,7 +1280,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1316,7 +1316,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1352,7 +1352,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1388,7 +1388,7 @@
             "restart": "passed",
             "server": "passed"
           },
-          "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f"
+          "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610"
         }
       ],
       "platform-targets": [
@@ -1420,7 +1420,7 @@
       "path": "src/extensions/evidence/runs"
     }
   ],
-  "source-digest": "sha256:8cb4d5dd9eaf398d4e3cc283777a30869c3be91138e8861145faa7d2c885617f",
+  "source-digest": "sha256:c836712ccd4a1f5d8c51092bd607e0e43d2968d76d8126cdb9252e9a84b1f610",
   "source-digest-inputs": [
     "src/postgres/versions/18/source.toml",
     "src/extensions/catalog/extensions.promoted.toml",

--- a/tools/release/sync_release_pr.py
+++ b/tools/release/sync_release_pr.py
@@ -40,6 +40,14 @@ ASSET_INPUT_FINGERPRINT_PATH = ROOT / "src/runtimes/liboliphaunt/wasix/assets/ge
 ASSET_INPUT_FINGERPRINT_MISMATCH_RE = re.compile(
     r"committed asset input fingerprint must be '([0-9a-f]+)', got '([0-9a-f]+)'"
 )
+EXTENSION_EVIDENCE_PATHS = [
+    ROOT / "src/extensions/evidence/matrix.toml",
+    ROOT / "src/extensions/evidence/runs/2026-06-07-transitional-catalog-smoke.json",
+    ROOT / "src/extensions/generated/docs/extension-evidence.json",
+]
+EXTENSION_EVIDENCE_STALE_RE = re.compile(
+    r"([^:\n]+\.json) sourceDigest is stale; expected (sha256:[0-9a-f]{64}), got '([^']*)'"
+)
 
 
 @dataclass(frozen=True)
@@ -474,6 +482,29 @@ def sync_asset_input_fingerprint(changes: list[Change], *, write: bool) -> None:
         changes.append(Change(ASSET_INPUT_FINGERPRINT_PATH, f"{old} -> {new}"))
 
 
+def sync_extension_evidence(changes: list[Change], *, write: bool) -> None:
+    command = ["python3", "src/extensions/tools/check-extension-model.py"]
+    command.append("--write-evidence" if write else "--check")
+    before = {path: read_optional_text(path) for path in EXTENSION_EVIDENCE_PATHS}
+    result = subprocess.run(command, cwd=ROOT, text=True, capture_output=True, check=False)
+    output = command_output_for_error(result)
+
+    if result.returncode != 0:
+        stale = EXTENSION_EVIDENCE_STALE_RE.findall(output)
+        if not write and stale:
+            for path_text, expected, actual in stale:
+                changes.append(Change(ROOT / path_text, f"{actual} -> {expected}"))
+            return
+        fail(f"`{' '.join(command)}` failed:\n{output}")
+
+    if not write:
+        return
+
+    for path in EXTENSION_EVIDENCE_PATHS:
+        if before[path] != read_optional_text(path):
+            changes.append(Change(path, "regenerated extension evidence"))
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--check", action="store_true", help="fail instead of writing updates")
@@ -487,6 +518,7 @@ def main() -> int:
     sync_cargo_path_dependency_pins(changes, write=write)
     sync_lockfiles(changes, write=write)
     sync_asset_input_fingerprint(changes, write=write)
+    sync_extension_evidence(changes, write=write)
 
     if not changes:
         print("release PR derived files are in sync")


### PR DESCRIPTION
## Summary
- Refresh extension evidence after release sync updates the WASIX asset input fingerprint.
- Commit the regenerated transitional evidence digest and generated evidence table for the current main release state.
- Keep future generated release PRs from breaking extension-native lanes after release-derived asset inputs change.

## Validation
- `python3 src/extensions/tools/check-extension-model.py --check`
- `tools/release/sync_release_pr.py --check`
- `tools/release/release.py check`
- `bun tools/policy/assertions/assert-source-inputs.mjs extensions`
- `python3 -m py_compile tools/release/sync_release_pr.py src/extensions/tools/check-extension-model.py`
- `git diff --check`